### PR TITLE
chore: add examples src to the dev aliase

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,6 +21,8 @@
     {:id  "maven-releases"
      :url "https://nexus.redplanetlabs.com/repository/maven-public-releases"}]]
   :profiles {:dev      {:resource-paths    ["test/resources/"]
+                        :source-paths      ["src/clj" "src/cljs" "resource"
+                                            "examples/clj"]
                         :java-source-paths ["src/java" "test/java"]
                         :dependencies
                         [[meander/epsilon "0.0.650"]


### PR DESCRIPTION
Allow working on AOR core code and examples in a single REPL session.