### PR TITLE
More granular exception tracking

### DIFF
--- a/src/clj/com/rpl/agent_o_rama/impl/agent_node.clj
+++ b/src/clj/com/rpl/agent_o_rama/impl/agent_node.clj
@@ -853,7 +853,7 @@
 (defn hook:appended-agent-failure [agent-task-id agent-id retry-num])
 
 (deframaop invoke-on-task-thread
-  [*agent-name *agent-task-id *agent-id *retry-num *afn *info]
+  [*agent-name *agent-task-id *agent-id *node *invoke-id *retry-num *afn *info]
   (<<with-substitutions
    [$$root (po/agent-root-task-global *agent-name)
     *failure-depot (po/agent-failures-depot-task-global *agent-name)]
@@ -863,9 +863,9 @@
      (|direct *agent-task-id)
      (local-transform>
       [(must *agent-id)
-       :exceptions
+       :exception-summaries
        AFTER-ELEM
-       (termval *s)]
+       (termval (aor-types/->ExceptionSummary *s *node *invoke-id))]
       $$root)
      (depot-partition-append!
       *failure-depot

--- a/src/clj/com/rpl/agent_o_rama/impl/core.clj
+++ b/src/clj/com/rpl/agent_o_rama/impl/core.clj
@@ -301,8 +301,11 @@
     (.thenApply
      (foreign-proxy-async
       [(keypath agent-id)
-       (submap [:result :exceptions :human-requests])
+       (submap [:result :exception-summaries :human-requests])
        (transformed :human-requests first)
+       (transformed [:exception-summaries ALL] :throwable-str)
+       (multi-transformed [(map-key :exception-summaries)
+                           (termval :exceptions)])
        (multi-transformed [(map-key :human-requests) (termval :human-request)])]
       root-pstate
       {:pkey        agent-task-id

--- a/src/clj/com/rpl/agent_o_rama/impl/pobjects.clj
+++ b/src/clj/com/rpl/agent_o_rama/impl/pobjects.clj
@@ -10,6 +10,7 @@
     AgentNodeEmit
     AgentResult
     AggInput
+    ExceptionSummary
     ForkContext
     NestedOpInfo
     NodeHumanInputRequest
@@ -92,7 +93,7 @@
      :invoke-args        [Object]
      :graph-version      Long
      :result             AgentResult
-     :exceptions         [String]
+     :exception-summaries [ExceptionSummary]
      :ack-val            Long
      :start-time-millis  Long
      :finish-time-millis Long
@@ -162,6 +163,7 @@
      :result              AgentResult
      :start-time-millis   Long
      :finish-time-millis  Long
+     :exceptions          [String] ; throwable strs
 
      :agg-invoke-id       UUID
 

--- a/src/clj/com/rpl/agent_o_rama/impl/types.clj
+++ b/src/clj/com/rpl/agent_o_rama/impl/types.clj
@@ -150,6 +150,11 @@
    nested-ops :- [NestedOpInfo]
   ])
 
+(drp/defrecord+ ExceptionSummary
+  [throwable-str :- String
+   node :- String
+   invoke-id :- UUID])
+
 (drp/defrecord+ AgentFailure
   [agent-task-id :- Long
    agent-id :- Long


### PR DESCRIPTION
- tracked at node level as well and included in traces
- root changed from throwable string to "ExceptionSummary" containing offending node name and invoke ID as well