### PR TITLE
fix: add init method to MultiAgg$Impl with RamaFunction conversion

### DIFF
--- a/src/clj/com/rpl/agent_o_rama/impl/multi_agg.clj
+++ b/src/clj/com/rpl/agent_o_rama/impl/multi_agg.clj
@@ -19,6 +19,7 @@
   [& body]
   `(reify
     ~'MultiAgg$Impl
+    (~'init [this# f#] (internal-add-init! this# (h/convert-jfn f#)))
     ~@(for [i (range 0 (- h/MAX-ARITY 1))]
         (let [name-sym (h/type-hinted String 'name#)
               jfn-sym  (h/type-hinted (h/rama-function-class (+ i 1)) 'jfn#)

--- a/test/clj/com/rpl/agent_o_rama/impl/multi_agg_test.clj
+++ b/test/clj/com/rpl/agent_o_rama/impl/multi_agg_test.clj
@@ -1,0 +1,69 @@
+(ns com.rpl.agent-o-rama.impl.multi-agg-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [com.rpl.agent-o-rama.impl.multi-agg :as ma])
+  (:import
+   [com.rpl.agentorama MultiAgg$Impl]
+   [com.rpl.rama.ops RamaFunction0 RamaFunction2]))
+
+(deftest mk-multi-agg-test
+  ;; Test that mk-multi-agg creates a functional MultiAgg instance
+  ;; that supports both Java interop (.init, .on methods) and
+  ;; internal protocol methods (internal-add-init!, internal-add-handler!)
+  (testing "mk-multi-agg"
+    (testing "creates instance with working internal protocol methods"
+      (let [agg (ma/mk-multi-agg)]
+        (ma/internal-add-init! agg (fn [] {:count 0}))
+        (ma/internal-add-handler! agg "increment" (fn [state] (update state :count inc)))
+
+        (let [state (ma/multi-agg-state agg)]
+          (is (fn? (:init-fn state)))
+          (is (= {:count 0} ((:init-fn state))))
+          (is (contains? (:on-handlers state) "increment"))
+          (is (= {:count 1} ((get (:on-handlers state) "increment") {:count 0}))))))
+
+    (testing "supports Java interop .init method"
+      (let [agg ^MultiAgg$Impl (ma/mk-multi-agg)
+            init-fn (reify RamaFunction0
+                      (invoke [_] {:total 0 :items []}))]
+        (.init agg init-fn)
+
+        (let [state (ma/multi-agg-state agg)
+              result ((:init-fn state))]
+          (is (= {:total 0 :items []} result)))))
+
+    (testing ".init method returns the MultiAgg instance for chaining"
+      (let [agg ^MultiAgg$Impl (ma/mk-multi-agg)
+            init-fn (reify RamaFunction0
+                      (invoke [_] {:sum 0}))
+            handler-fn (reify RamaFunction2
+                         (invoke [_ state val]
+                           (update state :sum + val)))
+            result (.on ^MultiAgg$Impl (.init agg init-fn) "add" handler-fn)]
+
+        (is (identical? agg result))
+
+        (let [state (ma/multi-agg-state agg)]
+          (is (= {:sum 0} ((:init-fn state))))
+          (is (contains? (:on-handlers state) "add"))
+          (is (= {:sum 5} ((get (:on-handlers state) "add") {:sum 0} 5))))))
+
+    (testing "prevents duplicate init registration"
+      (let [agg ^MultiAgg$Impl (ma/mk-multi-agg)
+            init-fn (reify RamaFunction0
+                      (invoke [_] {}))]
+        (.init agg init-fn)
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"MultiAgg already has init function specified"
+             (.init agg init-fn)))))
+
+    (testing "prevents duplicate handler registration"
+      (let [agg ^MultiAgg$Impl (ma/mk-multi-agg)
+            handler-fn (reify RamaFunction2
+                         (invoke [_ state val] state))]
+        (.on agg "test" handler-fn)
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"MultiAgg already has handler for given name"
+             (.on agg "test" handler-fn)))))))


### PR DESCRIPTION
Adds the missing .init() method to the MultiAgg$Impl reified object,
allowing Java code to call .init(ramaFunction) for method chaining.

The method properly converts the RamaFunction to a Clojure function
using convert-jfn, consistent with how the .on() methods handle
RamaFunction parameters.

Includes unit tests verifying:
- Java interop .init() method works correctly
- Method chaining with .init() and .on()
- RamaFunction conversion happens properly
- Duplicate registration prevention