### PR TITLE
chore: add data-id attributes to UI panels for testing

### DIFF
--- a/dev/ui-data-ids.md
+++ b/dev/ui-data-ids.md
@@ -1,0 +1,170 @@
+# UI Data IDs
+
+This document describes the `data-id` attributes used in the Agent-o-Rama UI for testing and element identification.
+
+## Agent Trace Display Panels
+
+The agent trace display consists of three main panels, each with a unique `data-id`:
+
+### Agent Graph Panel
+- **data-id**: `agent-graph-panel`
+- **Location**: Left side of the display (with right margin for info panel)
+- **Description**: Contains the visual graph representation of agent nodes and their connections using ReactFlow
+- **Contents**:
+  - Interactive graph visualization
+  - Node elements (custom and phantom types)
+  - Edges showing node connections
+  - MiniMap for navigation
+  - Background grid
+  - Controls for zoom/pan
+
+### Agent Info Panel
+- **data-id**: `agent-info-panel`
+- **Location**: Fixed right side panel
+- **Description**: Tabbed panel showing agent metadata and fork management
+- **Contents**:
+  - Tab navigation (Info and Fork tabs)
+  - Tab-specific content (see below)
+
+#### Info/Fork Tabs
+The Agent Info Panel contains two tabs:
+
+- **Info Tab**
+  - **data-id**: `info-tab`
+  - **Description**: Displays agent execution information and statistics
+  - **Sub-components**:
+    - `lineage-panel` - Parent/child fork relationships
+    - `final-result-section` - Result value with success/failure badge and "Add to Dataset" button
+    - `exceptions-panel` - List of exceptions with navigation to nodes
+    - `overall-stats-section` - Execution metrics (time, retries, store ops, model calls, tokens)
+
+- **Fork Tab**
+  - **data-id**: `fork-tab`
+  - **Description**: Shows and manages modified nodes for creating execution forks
+  - **Sub-components** (when changes exist):
+    - `fork-content` - Container for fork management UI
+    - `changed-nodes-list` - List of modified nodes with previews
+    - `fork-action-buttons` - Container for action buttons
+      - `execute-fork-button` - Executes the fork with changes
+      - `clear-fork-button` - Clears all changes
+  - **Sub-components** (when no changes):
+    - `fork-empty-state` - Message prompting user to select a node
+  - **Note**: Only visible when not in live mode
+
+### Node Invoke Details Panel
+- **data-id**: `node-invoke-details-panel`
+- **Location**: Bottom of the display, below the graph
+- **Description**: Shows detailed information about a selected node's invocation
+- **Contents**:
+  - Node name and ID
+  - Human input request interface (if applicable)
+  - Result data
+  - Exception details
+  - Timing information (start, finish, duration)
+  - Input arguments
+  - Nested operations (store ops, model calls, agent calls)
+  - Emits (child node invocations)
+  - "Add node to Dataset" button
+
+## Sub-components within Agent Info Panel
+
+### Info Tab Sub-components
+
+#### Lineage Panel
+- **data-id**: `lineage-panel`
+- **Description**: Shows fork ancestry and descendants
+- **Contents**:
+  - "Fork of" link to parent invocation (if this is a fork)
+  - List of child fork invocations with expandable "show all" feature
+
+#### Final Result Section
+- **data-id**: `final-result-section`
+- **Description**: Displays the agent's final result
+- **Contents**:
+  - Success/failure badge
+  - Result value (expandable data viewer)
+  - "Add to Dataset" button for the entire agent invocation
+
+#### Exceptions Panel
+- **data-id**: `exceptions-panel`
+- **Description**: Lists all exceptions that occurred during execution
+- **Contents**:
+  - Exception count
+  - For each exception:
+    - Node name where it occurred
+    - First line of exception message (clickable to expand)
+    - "Go to Node" button (if node is loaded)
+
+#### Overall Stats Section
+- **data-id**: `overall-stats-section`
+- **Description**: Displays execution metrics
+- **Contents**:
+  - Execution time (milliseconds)
+  - Retry count (if any retries occurred)
+  - Store operations (reads and writes)
+  - Model calls count
+  - Total tokens used
+
+### Fork Tab Sub-components
+
+#### Fork Content (when changes exist)
+- **data-id**: `fork-content`
+- **Description**: Container for all fork management UI
+- **Child components**:
+  - Changed nodes list
+  - Action buttons
+
+#### Changed Nodes List
+- **data-id**: `changed-nodes-list`
+- **Description**: Shows all nodes that have been modified for forking
+- **Contents**: For each changed node:
+  - Node name and ID
+  - Warning indicator if node is overridden by upstream changes
+  - Preview of new input (truncated if long)
+  - "Remove" button to undo the change
+
+#### Fork Action Buttons
+- **data-id**: `fork-action-buttons`
+- **Description**: Container for fork execution controls
+- **Child buttons**:
+  - `execute-fork-button` - Creates and executes a new fork with the changes
+  - `clear-fork-button` - Removes all pending changes
+
+#### Fork Empty State
+- **data-id**: `fork-empty-state`
+- **Description**: Shown when no nodes have been modified yet
+- **Contents**: Instructional message
+
+## Usage in Testing
+
+These `data-id` attributes can be used in automated tests to reliably select elements:
+
+```javascript
+// Example: Select the agent graph panel
+const graphPanel = document.querySelector('[data-id="agent-graph-panel"]');
+
+// Example: Select the info tab
+const infoTab = document.querySelector('[data-id="info-tab"]');
+
+// Example: Check if node details panel is visible
+const detailsPanel = document.querySelector('[data-id="node-invoke-details-panel"]');
+
+// Example: Access sub-components
+const lineagePanel = document.querySelector('[data-id="lineage-panel"]');
+const exceptionsPanel = document.querySelector('[data-id="exceptions-panel"]');
+const executeForkButton = document.querySelector('[data-id="execute-fork-button"]');
+```
+
+## Panel Visibility
+
+- **Agent Graph Panel**: Always visible when graph data is available
+- **Agent Info Panel**: Always visible (fixed position)
+  - **Info Tab**: Always available
+    - `lineage-panel`: Only visible when forks or parent exist
+    - `final-result-section`: Only visible when result exists
+    - `exceptions-panel`: Only visible when exceptions occurred
+    - `overall-stats-section`: Always visible
+  - **Fork Tab**: Only visible when not in live mode (`is-live` is false)
+    - `fork-content` + children: Only visible when changes exist
+    - `fork-empty-state`: Only visible when no changes exist
+- **Node Invoke Details Panel**: Only visible when a node is selected

--- a/src/cljs/com/rpl/agent_o_rama/ui/invocation_graph_view.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/invocation_graph_view.cljs
@@ -283,7 +283,8 @@
                                      [:ui :hitl :submitting :placeholder]))]
 
     (when selected-node
-      ($ :div {:className (common/cn "mt-6 bg-white shadow-lg rounded-lg border border-gray-200 max-w-4xl")}
+      ($ :div {:className (common/cn "mt-6 bg-white shadow-lg rounded-lg border border-gray-200 max-w-4xl")
+               :data-id "node-invoke-details-panel"}
          ($ :div {:className "p-6"}
             ;; Human input section
             (when hr
@@ -323,7 +324,6 @@
                   ($ :span {:className "text-sm font-medium text-indigo-700"} "ID")
                   ($ :span {:className "text-xs text-indigo-500 font-mono"} (str node-id)))
                ;; Add to Dataset button for individual node
-                              ;; Add to Dataset button for individual node
                ($ :div {:className "mt-3"}
                   ($ :button
                      {:className "text-sm font-medium py-1 px-3 rounded-md transition-colors bg-green-100 text-green-800 hover:bg-green-200"
@@ -573,7 +573,8 @@
                           sorted-forks
                           (take 5 sorted-forks))]
     (when has-lineage?
-      ($ :div {:className "bg-gray-50 p-4 rounded-lg border border-gray-200 mb-4"}
+      ($ :div {:className "bg-gray-50 p-4 rounded-lg border border-gray-200 mb-4"
+               :data-id "lineage-panel"}
          ($ :h4 {:className "text-md font-semibold text-gray-700 mb-2"} "Lineage")
          ($ :div {:className "space-y-2"}
 
@@ -611,7 +612,8 @@
 (defui exceptions-panel [{:keys [summary-data graph-data on-select-node]}]
   (let [exceptions (get-in summary-data [:exception-summaries])]
     (when (seq exceptions)
-      ($ :div {:className (common/cn "bg-red-50 p-3 rounded-lg border border-red-200")}
+      ($ :div {:className (common/cn "bg-red-50 p-3 rounded-lg border border-red-200")
+               :data-id "exceptions-panel"}
          ($ :div {:className "text-sm font-medium text-red-700 mb-2 flex items-center gap-2"}
             ($ ExclamationTriangleIcon {:className "w-5 h-5"})
             (str "Exceptions (" (count exceptions) ")"))
@@ -666,7 +668,8 @@
                          :fork-of fork-of})
 
        (when result
-         ($ :div {:className "bg-gray-50 p-3 rounded-lg border border-gray-200"}
+         ($ :div {:className "bg-gray-50 p-3 rounded-lg border border-gray-200"
+                  :data-id "final-result-section"}
             ($ :div {:className "flex justify-between items-center mb-2"}
                ($ :div {:className "text-sm font-medium text-gray-700"} "Final Result")
                (if failure?
@@ -694,7 +697,9 @@
                             :graph-data graph-data
                             :on-select-node on-select-node})
 
-       ($ :div {:className "text-sm font-medium text-gray-700 pt-2 border-t border-gray-200"} "Overall Stats")
+       ($ :div {:className "text-sm font-medium text-gray-700 pt-2 border-t border-gray-200"
+                :data-id "overall-stats-section"}
+          "Overall Stats")
 
        ;; Metrics grid
        (let [total-nodes (count graph-data)
@@ -773,13 +778,15 @@
          (state/dispatch [:db/set-value [:ui :active-tab] :info])))
      [is-live changed-nodes])
 
-    ($ :div {:className (common/cn "fixed right-0 top-32 h-[calc(100vh-8rem)] w-80 bg-white shadow-lg border-l border-gray-200 overflow-hidden z-40")}
+    ($ :div {:className (common/cn "fixed right-0 top-32 h-[calc(100vh-8rem)] w-80 bg-white shadow-lg border-l border-gray-200 overflow-hidden z-40")
+             :data-id "agent-info-panel"}
        ;; Tab header
        ($ :div {:className (common/cn "border-b border-gray-200 p-4")}
           ($ :div {:className (common/cn "flex space-x-1 bg-gray-100 rounded-lg p-1")}
              ($ :button {:className (common/cn "flex-1 py-2 px-3 text-sm font-medium rounded-md transition-colors"
                                                {"bg-white text-gray-900 shadow-sm" (= active-tab :info)
                                                 "text-gray-600 hover:text-gray-900" (not= active-tab :info)})
+                         :data-id "info-tab"
                          :onClick #(state/dispatch [:db/set-value [:ui :active-tab] :info])}
                 "Info")
              ;; Only show Fork tab when not in live mode
@@ -787,6 +794,7 @@
                ($ :button {:className (common/cn "flex-1 py-2 px-3 text-sm font-medium rounded-md transition-colors"
                                                  {"bg-white text-gray-900 shadow-sm" (= active-tab :fork)
                                                   "text-gray-600 hover:text-gray-900" (not= active-tab :fork)})
+                           :data-id "fork-tab"
                            :onClick #(state/dispatch [:db/set-value [:ui :active-tab] :fork])}
                   (str "Fork" (when (> (count changed-nodes) 0) (str " (" (count changed-nodes) ")")))))))
 
@@ -803,58 +811,64 @@
                                  :fork-of fork-of})
 
             :fork (if (empty? changed-nodes)
-                    ($ :div {:className "text-gray-500 text-center py-8"}
+                    ($ :div {:className "text-gray-500 text-center py-8"
+                             :data-id "fork-empty-state"}
                        "No changes yet. Select a node to edit its input.")
 
-                    ($ :div {:className "space-y-3"}
+                    ($ :div {:className "space-y-3"
+                             :data-id "fork-content"}
                        ;; Changed nodes list
-                       (for [[node-id new-input] changed-nodes]
-                         (let [node-data (get graph-data node-id)
-                               node-name (:node node-data)
-                               is-overridden (contains? affected-nodes node-id)
-                               handle-select-node (fn [e]
-                                                    (.stopPropagation e)
-                                                    ;; Find the corresponding flow node and select it
-                                                    (let [nodes (js->clj flow-nodes :keywordize-keys true)
-                                                          target-node (->> nodes
-                                                                           (filter #(= (-> % :data :node-id) node-id))
-                                                                           first)]
-                                                      (when (and target-node on-select-node)
-                                                        (on-select-node node-id))))]
+                       ($ :div {:data-id "changed-nodes-list"}
+                          (for [[node-id new-input] changed-nodes]
+                            (let [node-data (get graph-data node-id)
+                                  node-name (:node node-data)
+                                  is-overridden (contains? affected-nodes node-id)
+                                  handle-select-node (fn [e]
+                                                       (.stopPropagation e)
+                                                       ;; Find the corresponding flow node and select it
+                                                       (let [nodes (js->clj flow-nodes :keywordize-keys true)
+                                                             target-node (->> nodes
+                                                                              (filter #(= (-> % :data :node-id) node-id))
+                                                                              first)]
+                                                         (when (and target-node on-select-node)
+                                                           (on-select-node node-id))))]
 
-                           ($ :div {:key node-id
-                                    :className (common/cn "border rounded-lg p-3 cursor-pointer hover:shadow-md transition-shadow"
-                                                          {"bg-yellow-50 border-yellow-300 hover:bg-yellow-100" is-overridden
-                                                           "bg-gray-50 border-gray-200 hover:bg-gray-100" (not is-overridden)})
-                                    :onClick handle-select-node}
-                              ($ :div {:className "flex justify-between items-start mb-2"}
-                                 ($ :div
-                                    ($ :div {:className "font-medium text-gray-800 text-sm flex items-center gap-2"}
-                                       node-name)
-                                    ($ :div {:className "text-xs text-gray-500 font-mono"} (str "ID: " node-id))
-                                    (when is-overridden
-                                      ($ :div {:className "bg-yellow-200 text-yellow-800 text-xs px-2 py-1 rounded mt-1 font-medium"}
-                                         "⚠️ This change will not be reached")))
-                                 ($ :button {:className "cursor-pointer text-red-500 hover:text-red-700 text-sm"
-                                             :onClick (fn [e]
-                                                        (.stopPropagation e)
-                                                        (when on-remove-node-change
-                                                          (on-remove-node-change node-id)))}
-                                    "Remove"))
+                              ($ :div {:key node-id
+                                       :className (common/cn "border rounded-lg p-3 cursor-pointer hover:shadow-md transition-shadow"
+                                                             {"bg-yellow-50 border-yellow-300 hover:bg-yellow-100" is-overridden
+                                                              "bg-gray-50 border-gray-200 hover:bg-gray-100" (not is-overridden)})
+                                       :onClick handle-select-node}
+                                 ($ :div {:className "flex justify-between items-start mb-2"}
+                                    ($ :div
+                                       ($ :div {:className "font-medium text-gray-800 text-sm flex items-center gap-2"}
+                                          node-name)
+                                       ($ :div {:className "text-xs text-gray-500 font-mono"} (str "ID: " node-id))
+                                       (when is-overridden
+                                         ($ :div {:className "bg-yellow-200 text-yellow-800 text-xs px-2 py-1 rounded mt-1 font-medium"}
+                                            "⚠️ This change will not be reached")))
+                                    ($ :button {:className "cursor-pointer text-red-500 hover:text-red-700 text-sm"
+                                                :onClick (fn [e]
+                                                           (.stopPropagation e)
+                                                           (when on-remove-node-change
+                                                             (on-remove-node-change node-id)))}
+                                       "Remove"))
 
-                              ($ :div {:className "text-xs"}
-                                 ($ :div {:className "text-gray-600 mb-1"} "New input:")
-                                 ($ :div {:className "bg-white p-2 rounded border font-mono text-gray-800 break-all"}
-                                    (if (> (count new-input) 100)
-                                      (str (subs new-input 0 100) "...")
-                                      new-input))))))
+                                 ($ :div {:className "text-xs"}
+                                    ($ :div {:className "text-gray-600 mb-1"} "New input:")
+                                    ($ :div {:className "bg-white p-2 rounded border font-mono text-gray-800 break-all"}
+                                       (if (> (count new-input) 100)
+                                         (str (subs new-input 0 100) "...")
+                                         new-input)))))))
 
                        ;; Action buttons
-                       ($ :div {:className "pt-4 border-t border-gray-200 space-y-2"}
+                       ($ :div {:className "pt-4 border-t border-gray-200 space-y-2"
+                                :data-id "fork-action-buttons"}
                           ($ :button {:className "w-full font-medium py-2 px-4 rounded-md transition-colors bg-blue-600 hover:bg-blue-700 text-white"
+                                      :data-id "execute-fork-button"
                                       :onClick on-execute-fork}
                              (str "Execute Fork (" (count changed-nodes) " changes)"))
                           ($ :button {:className "w-full bg-gray-300 hover:bg-gray-400 text-gray-700 font-medium py-2 px-4 rounded-md transition-colors"
+                                      :data-id "clear-fork-button"
                                       :onClick on-clear-fork}
                              "Clear All Changes")))))))))
 
@@ -975,7 +989,8 @@
          ($ :div.text-gray-500 "No graph data available"))
       ($ :<>
          ;; Main content area with right margin for the stats panel
-         ($ :div {:className "mr-80"}
+         ($ :div {:className "mr-80"
+                  :data-id "agent-graph-panel"}
             ($ :div {:style {:width "100%" :height "500px"}}
                ($ ReactFlow {:nodes flow-nodes
                              :edges flow-edges


### PR DESCRIPTION
Add data-id attributes to all major panels and sub-components in the
agent trace display UI for easier testing and element identification.

Changes:
- Add data-id to three main panels:
  - agent-graph-panel (left graph visualization)
  - agent-info-panel (right panel with tabs)
  - node-invoke-details-panel (bottom node details)

- Add data-id to tab navigation:
  - info-tab
  - fork-tab

- Add data-id to Info tab sub-components:
  - lineage-panel
  - final-result-section
  - exceptions-panel
  - overall-stats-section

- Add data-id to Fork tab sub-components:
  - fork-content
  - fork-empty-state
  - changed-nodes-list
  - fork-action-buttons
  - execute-fork-button
  - clear-fork-button

- Create dev/ui-data-ids.md documenting all data-ids with:
  - Panel descriptions and locations
  - Sub-component hierarchy
  - Content descriptions
  - Usage examples for testing
  - Visibility rules for conditional panels