### PR TITLE
chore: add missing shadow-cljs dep to dev profile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -59,7 +59,8 @@
                          [meander/epsilon "0.0.650"]
                          [dev.langchain4j/langchain4j-open-ai "1.4.0"]
                          [dev.langchain4j/langchain4j-web-search-engine-tavily
-                          "1.3.0-beta9"]]}
+                          "1.3.0-beta9"]
+                         [thheller/shadow-cljs "3.1.7"]]}
              :provided {:dependencies
                         ;; TODO: fix Rama version
                         [[com.rpl/rama "0.0.6-SNAPSHOT"]


### PR DESCRIPTION
Dev now needs the shadow-cljs dependency