### PR TITLE
fix: ensure random-task-id returns a Long

### DIFF
--- a/src/clj/com/rpl/agent_o_rama/impl/analytics.clj
+++ b/src/clj/com/rpl/agent_o_rama/impl/analytics.clj
@@ -42,7 +42,7 @@
 (def ^:dynamic ACTION-HELPERS)
 (defn declared-objects ^AgentDeclaredObjectsTaskGlobal [] (:declared-objects ACTION-HELPERS))
 (defn rama-clients ^RamaClientsTaskGlobal [] (:rama-clients ACTION-HELPERS))
-(defn random-task-id [] (rand-int (:num-tasks ACTION-HELPERS)))
+(defn random-task-id [] (long (rand-int (:num-tasks ACTION-HELPERS))))
 
 
 (defn get-num-tasks


### PR DESCRIPTION
The schemas enforce Long for the task-id.