### PR TITLE
fix: wrap llm-judge template values with str to handle non-strings

### DIFF
--- a/src/clj/com/rpl/agent_o_rama/impl/evaluators.clj
+++ b/src/clj/com/rpl/agent_o_rama/impl/evaluators.clj
@@ -122,9 +122,9 @@ Be strict: minor wording differences are acceptable, but factual errors, omissio
         (fn [fetcher input ref-output output]
           (let [model  (.getAgentObject ^AgentObjectFetcher fetcher model-name)
                 prompt (-> prompt-template
-                           (str/replace "%input" input)
-                           (str/replace "%output" output)
-                           (str/replace "%referenceOutput" ref-output))]
+                           (str/replace "%input" (str input))
+                           (str/replace "%output" (str output))
+                           (str/replace "%referenceOutput" (str ref-output)))]
             (-> model
                 (lc4j/chat
                  (lc4j/chat-request

--- a/test/clj/com/rpl/evaluators_test.clj
+++ b/test/clj/com/rpl/evaluators_test.clj
@@ -374,6 +374,10 @@
        (let [expected-schema-str (schema->json-string (lj/from-json-string os))]
         (is (= expected-schema-str (get result "outputSchema")))))
 
+     ;; Verify non-string values are converted to strings in template
+     (let [result (aor/try-evaluator manager "ajudge" 42 100 200)]
+       (is (= "1 42 2 100 3 200 4 42" (get result "message"))))
+
      (try
        (aor/create-evaluator! manager
                               "ajudge"


### PR DESCRIPTION
## Summary

Ensure template interpolation values passed to llm-judge are converted to strings using `str` function to handle non-string values properly.

The `aor/llm-judge` builder in evaluators.clj uses `str/replace` for template interpolation, but `str/replace` throws `ClassCastException` if the replacement value is not a string.

## Changes

- Wrap `input`, `output`, and `ref-output` with `str` before passing to `str/replace` in evaluators.clj lines 124-127
- Add test case verifying non-string values (integers) work correctly

## Test plan

- [x] Existing tests pass
- [x] New test verifies non-string values don't throw exceptions