### PR TITLE
POC: spel as a Clojure-native replacement for Playwright + Etaoin

### DIFF
--- a/.github/workflows/spel.yml
+++ b/.github/workflows/spel.yml
@@ -1,0 +1,119 @@
+name: Spel E2E Tests (POC)
+# Proof-of-concept: same tests as playwright.yml but written in Clojure
+# using spel (Playwright Java wrapper) instead of Node.js Playwright.
+# Server setup is identical — only the test runner changes.
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  spel:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@12.5
+      with:
+        lein: latest
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Cache Leiningen dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-lein-spel-${{ hashFiles('project.clj') }}
+        restore-keys: |
+          ${{ runner.os }}-lein-spel-
+          ${{ runner.os }}-lein-
+
+    - name: Cache Node modules
+      uses: actions/cache@v4
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - name: Install dependencies
+      run: |
+        lein with-profile +dev,+spel deps
+        npm ci
+
+    - name: Install Playwright browsers (Java)
+      # spel uses playwright-java which ships its own browser installer
+      run: lein with-profile +dev,+spel run -m com.microsoft.playwright.CLI install chromium
+
+    - name: Build production frontend
+      env:
+        NODE_ENV: production
+      run: |
+        rm -rf resource/public
+        mkdir -p resource/public
+        cp -r resource/assets/* resource/public
+        lein with-profile +ui run -m shadow.cljs.devtools.cli release :frontend
+
+    - name: Start server
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        CI: true
+      run: |
+        lein with-profile +dev,+ui run -m ci-playwright-setup --no-frontend &
+        SERVER_PID=$!
+        echo "SERVER_PID=$SERVER_PID" >> $GITHUB_ENV
+
+        echo "Waiting for server to start..."
+        timeout=180
+        elapsed=0
+        while [ $elapsed -lt $timeout ]; do
+          if curl -f http://localhost:1974 > /dev/null 2>&1; then
+            echo "Server is ready!"
+            break
+          fi
+          sleep 2
+          elapsed=$((elapsed + 2))
+          echo "Waiting... ($elapsed/$timeout seconds)"
+        done
+
+        if [ $elapsed -ge $timeout ]; then
+          echo "Server failed to start within $timeout seconds"
+          kill $SERVER_PID 2>/dev/null || true
+          exit 1
+        fi
+
+    - name: Run spel tests
+      env:
+        CI: true
+      run: |
+        lein with-profile +dev,+spel run -m lazytest.main \
+          --namespace com.rpl.agent-o-rama.ui.spel-navigation-test
+
+    - name: Upload Allure results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: spel-allure-results
+        path: allure-results/
+        retention-days: 30
+
+    - name: Cleanup
+      if: always()
+      run: |
+        if [ -n "$SERVER_PID" ]; then
+          kill $SERVER_PID 2>/dev/null || true
+        fi
+        pkill -f "ci-playwright-setup" || true

--- a/project.clj
+++ b/project.clj
@@ -97,6 +97,9 @@
                                          [net.java.dev.jna/jna "5.17.0"]
                                          [org.clojure/clojure "1.12.2"]
                                          [prismatic/schema "1.4.1"]]}
+             :spel       {:source-paths ["test/clj"]
+                          :dependencies [[com.blockether/spel "0.7.3"]
+                                         [io.github.noahtheduke/lazytest "1.9.1"]]}
              :test       {:jvm-opts ["-Daor.test.runner=1"]}
              :nrepl-port {:repl-options {:port 7888}}}
   :codox {:source-paths ["src/clj"]

--- a/test/clj/com/rpl/agent_o_rama/ui/spel_navigation_test.clj
+++ b/test/clj/com/rpl/agent_o_rama/ui/spel_navigation_test.clj
@@ -1,0 +1,68 @@
+(ns com.rpl.agent-o-rama.ui.spel-navigation-test
+  "POC: navigation.spec.js tests rewritten in Clojure using spel
+   (idiomatic Clojure wrapper for Playwright Java).
+
+   Why this is interesting vs. the current setup:
+
+   vs. Playwright (Node.js):
+   - Pure Clojure — no context switch between infra code and test code
+   - Can call aor/agent-initiate, wait-for-microbatch-processed-count, etc.
+     directly in the test body without a helper server or shared state
+   - Allure reporting with embedded Playwright traces out of the box
+   - Same server setup (ci-playwright-setup) reused unchanged
+
+   vs. Etaoin:
+   - Backed by Playwright Java instead of Selenium — faster, more reliable
+   - Chromium/Firefox/WebKit support without Docker containers
+   - Semantic selectors: get-by-role, get-by-text, get-by-label
+   - Auto-waiting on all actions (no explicit Thread/sleep or wait-visible loops)
+
+   To run locally (server must be running on port 1974):
+     lein with-profile +dev,+spel run -m lazytest.main \\
+       --namespace com.rpl.agent-o-rama.ui.spel-navigation-test"
+  (:require
+   [com.blockether.spel.allure :refer [defdescribe describe it expect]]
+   [com.blockether.spel.locator :as locator]
+   [com.blockether.spel.page :as page]
+   [com.blockether.spel.test-fixtures
+    :refer [*page* with-browser with-page with-playwright]])
+  (:import
+   [com.microsoft.playwright.options AriaRole]))
+
+(def ^:private base-url "http://localhost:1974")
+
+(def ^:private e2e-agent-row-name
+  "com.rpl.agent.e2e-test-agent/E2ETestAgentModule E2ETestAgent")
+
+;; Browser lifecycle: one Playwright instance → one Browser → fresh Page per test.
+;; The application server is started externally (same as playwright.yml).
+(defdescribe navigation-tests
+  {:context [with-playwright with-browser with-page]}
+
+  (describe "e2e test agent module exists"
+
+    (it "loads the homepage and navigates to an agent detail page"
+      (page/set-default-timeout! *page* 30000)
+      (page/navigate *page* base-url)
+      (expect (re-find #"Agent-o-rama" (page/title *page*)))
+
+      ;; Playwright auto-waits up to the default timeout for the row to appear.
+      (let [agent-row (page/get-by-role *page* AriaRole/ROW
+                                        {:name e2e-agent-row-name})]
+        (locator/click agent-row)
+        (expect (re-find #"/agents/.*E2ETestAgentModule" (page/url *page*))))))
+
+  (describe "navigation bar"
+
+    (it "datasets link is visible on agent detail page"
+      (page/set-default-timeout! *page* 30000)
+      (page/navigate *page* base-url)
+
+      (let [agent-row (page/get-by-role *page* AriaRole/ROW
+                                        {:name e2e-agent-row-name})]
+        (locator/click agent-row))
+
+      (let [datasets-link (page/get-by-text *page* "Datasets & Experiments")]
+        (expect (locator/is-visible? datasets-link))
+        (locator/click datasets-link)
+        (expect (re-find #"/datasets" (page/url *page*)))))))


### PR DESCRIPTION
## What is spel?

[spel](https://github.com/Blockether/spel) is an idiomatic Clojure wrapper for Playwright Java. Same browser engine (Chromium/Firefox/WebKit), but the tests are pure Clojure.

## What this PR does

Ports the first two test suites from `navigation.spec.js` into `spel_navigation_test.clj` to demonstrate the concept. The server setup is unchanged — same `ci-playwright-setup`, same port 1974.

## Why it's interesting

**vs. our Node.js Playwright tests:**
- No context switch — test infra (Clojure) and test code are the same language
- Can call `aor/agent-initiate`, `wait-for-microbatch-processed-count`, etc. directly in the test body without a helper server
- Allure reporting with embedded Playwright traces out of the box

**vs. Etaoin:**
- Playwright Java instead of Selenium — faster, more reliable selectors
- No Docker container needed for the browser (playwright-java handles it)
- Semantic selectors: `get-by-role`, `get-by-text`, `get-by-label`
- Auto-waiting on all actions — no `Thread/sleep` or `wait-visible` polling loops

## Changes

- `project.clj` — new `:spel` profile with `com.blockether/spel` + `lazytest`
- `test/clj/.../spel_navigation_test.clj` — spel port of `navigation.spec.js` first two suites
- `.github/workflows/spel.yml` — CI workflow (identical server setup, lazytest runner)

## What would full adoption look like?

- Replace `navigation.spec.js` et al. with Clojure equivalents in `test/clj/com/rpl/agent_o_rama/ui/`
- Replace etaoin tests with spel equivalents (no Selenium container needed)
- Single CI workflow instead of two (`playwright.yml` + `etaoin.yml`)
- Drop `etaoin`, `clj-test-containers`, `testcontainers` from deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)