### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Agent-o-rama is a Clojure/ClojureScript LLM agent platform built on Rama. No external infrastructure (databases, Docker, etc.) is needed — Rama's in-process cluster (IPC) handles everything in a single JVM.
+
+### Prerequisites
+
+- **JDK 21+** (pre-installed)
+- **Leiningen** (`lein`) — Clojure build tool; install via `curl -fsSL https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein | sudo tee /usr/local/bin/lein > /dev/null && sudo chmod +x /usr/local/bin/lein && lein version`
+- **Node.js 20+** and **npm** (pre-installed)
+
+### Common commands
+
+See `dev/claude/CLAUDE.md` for the full list. Key commands:
+
+| Task | Command |
+|---|---|
+| Install npm deps | `npm ci` |
+| Fetch JVM deps | `lein with-profile +dev,+ui,+provided deps` |
+| Compile ClojureScript frontend | `lein with-profile +ui run -m shadow.cljs.devtools.cli --npm compile :frontend` |
+| Run Clojure tests (default, no UI tests) | `lein test` |
+| Run ClojureScript tests | `node target/test/test.js` (after compiling with `lein with-profile +ui run -m shadow.cljs.devtools.cli compile :test`) |
+| Start app (IPC + UI on port 1974) | `lein with-profile +dev,+ui run -m ci-playwright-setup --no-frontend` |
+| Start REPL with UI support | `lein with-profile +ui,+nrepl-port repl` |
+
+### Non-obvious caveats
+
+- **JVM memory**: The project requires `-Xms6g -Xmx6g` (6 GB heap) and `-Xss6m` stack. These are set in `project.clj` `:jvm-opts`. Ensure the VM has at least 8 GB RAM.
+- **IPC tests are slow**: Each Clojure test that creates an IPC spins up/down a full in-process Rama cluster. The full `lein test` suite takes ~15-20 minutes.
+- **Frontend must be pre-compiled before starting the app**: Run the ClojureScript compile step before launching `ci-playwright-setup --no-frontend`. The compiled output goes to `resource/public/`.
+- **UI test selectors**: `lein test` runs the `:default` selector which excludes `com.rpl.agent-o-rama.ui.*` namespaces. Use `lein test :ui` for Etaoin browser tests (needs ChromeDriver) or `lein test :all` for everything.
+- **Rama dependencies come from a custom Maven repo**: `https://nexus.redplanetlabs.com/repository/maven-public-releases` — this is configured in `project.clj` `:repositories`.
+- **Optional API keys**: `OPENAI_API_KEY` and `TAVILY_API_KEY` are only needed for LLM-based example agents and some integration tests. Core tests pass without them.
+- **Port 1974**: The Agent-o-rama web UI listens on this port by default.
+- **`resource/assets/`** contains static assets (logos) that should be copied to `resource/public/` before serving the frontend.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific development instructions for future cloud agents.

## What's included

- Quick-reference table of common development commands (build, test, run)
- Non-obvious caveats discovered during setup (JVM memory requirements, IPC test duration, custom Maven repo, frontend pre-compilation requirement, test selectors, etc.)
- Prerequisites and port information

## Verification

The development environment was fully set up and verified:

- **Clojure tests**: 124 tests, 2602 assertions, 0 failures, 0 errors
- **ClojureScript tests**: 34 tests, 281 assertions, 0 failures, 0 errors
- **Frontend compilation**: shadow-cljs compiled successfully
- **Application startup**: IPC + UI running on port 1974 with 3 agent modules deployed
- **Agent invocation**: Successfully invoked BasicAgent through the web UI

[agent_o_rama_demo.mp4](https://cursor.com/agents/bc-9ddbf4a9-f785-4e7b-842e-89a5fef331d9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_o_rama_demo.mp4)

[Home page showing deployed modules](https://cursor.com/agents/bc-9ddbf4a9-f785-4e7b-842e-89a5fef331d9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_page_modules.webp)
[Successful agent invocation](https://cursor.com/agents/bc-9ddbf4a9-f785-4e7b-842e-89a5fef331d9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_invocation_result.webp)
[Analytics dashboard](https://cursor.com/agents/bc-9ddbf4a9-f785-4e7b-842e-89a5fef331d9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fanalytics_dashboard.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ddbf4a9-f785-4e7b-842e-89a5fef331d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ddbf4a9-f785-4e7b-842e-89a5fef331d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

