### PR TITLE
Bump shadow-cljs to 3.1.7 and Playwright to 1.59.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       "devDependencies": {
         "@playwright/test": "^1.55.0",
         "jsdom": "^25.0.1",
-        "shadow-cljs": "3.0.5"
+        "shadow-cljs": "3.1.7"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -184,13 +184,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
-      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.55.0"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1074,13 +1074,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
-      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.55.0"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1093,9 +1093,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
-      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1354,12 +1354,14 @@
       }
     },
     "node_modules/shadow-cljs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-3.0.5.tgz",
-      "integrity": "sha512-FXfJ0wQ+o5zF5CK7Zny265LvSaMacAxPMM0Am1fiwxa3zAsIdBQq7Hd5QsD6sHGiYw+2m0lWK6fao4k9yLNW4g==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-3.1.7.tgz",
+      "integrity": "sha512-q1SCy5m5EpNfrn6C0vKa2ho6gwW6rdSU1Ge22HbbZ813TpR/1hBXdlgTF2RE49yIqJxxhVtfcLz0jWa0Ul32IQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
+        "buffer": "^6.0.3",
+        "process": "^0.11.10",
         "readline-sync": "^1.4.10",
         "shadow-cljs-jar": "1.3.4",
         "source-map-support": "^0.5.21",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@playwright/test": "^1.55.0",
     "jsdom": "^25.0.1",
-    "shadow-cljs": "3.0.5"
+    "shadow-cljs": "3.1.7"
   },
   "dependencies": {
     "@dagrejs/dagre": "^1.1.5",


### PR DESCRIPTION
## Summary

- **shadow-cljs**: `package.json` pinned `3.0.5` while `project.clj` already required `3.1.7`. The two compilers must stay in lockstep — bumping `package.json` to `3.1.7` removes the drift.
- **Playwright**: `npm audit` flagged [GHSA-7mvr-c777-76hp](https://github.com/advisories/GHSA-7mvr-c777-76hp) (browser binaries downloaded without SSL cert verification, fixed in `1.55.1`). The existing `"^1.55.0"` range was preserved; lockfile regeneration resolved Playwright to `1.59.1`.
- No source code changes; lockfile-only deltas otherwise.

## Test plan

- [ ] `npm install` — clean install, no audit warnings (`npm audit` reports 0 vulnerabilities locally).
- [ ] `lein with-profile +ui run -m shadow.cljs.devtools.cli --npm compile :frontend` — frontend builds.
- [ ] `npx playwright test` — E2E suite still passes against the bumped Playwright.