### PR TITLE
Refactor invocation trace data flow (Gantt / React Flow)

### DIFF
--- a/src/clj/com/rpl/agent_o_rama/impl/ui/rpc/invocations.clj
+++ b/src/clj/com/rpl/agent_o_rama/impl/ui/rpc/invocations.clj
@@ -60,7 +60,7 @@
                 (aor-types/underlying-objects client)))}
       {:graph nil})))
 
-(defn- trace-graph-complete?
+(defn trace-graph-complete?
   "True when every reachable drawable node in the trace has :finish-time-millis."
   [nodes root-invoke-id]
   (when (and (seq nodes) root-invoke-id (contains? nodes root-invoke-id))
@@ -87,7 +87,7 @@
                                                       (:node (get nodes %)))
                                                 emitted-ids)]
                   (recur (into remaining drawable-children)
-                         (conj visited current-id))))))))))
+                         (conj visited current-id)))))))))))
 
 (defn get-graph-page!!
   [system {:keys [module-id agent-name invoke-id]}]

--- a/src/clj/com/rpl/agent_o_rama/impl/ui/rpc/invocations.clj
+++ b/src/clj/com/rpl/agent_o_rama/impl/ui/rpc/invocations.clj
@@ -60,6 +60,35 @@
                 (aor-types/underlying-objects client)))}
       {:graph nil})))
 
+(defn- trace-graph-complete?
+  "True when every reachable drawable node in the trace has :finish-time-millis."
+  [nodes root-invoke-id]
+  (when (and (seq nodes) root-invoke-id (contains? nodes root-invoke-id))
+    (loop [to-visit #{root-invoke-id}
+           visited #{}]
+      (if (empty? to-visit)
+        true
+        (let [current-id (first to-visit)
+              remaining (disj to-visit current-id)]
+          (if (visited current-id)
+            (recur remaining visited)
+            (let [node-data (get nodes current-id)
+                  node-name (:node node-data)]
+              (cond
+                (not node-name)
+                (recur remaining (conj visited current-id))
+
+                (not (:finish-time-millis node-data))
+                false
+
+                :else
+                (let [emitted-ids (set (map :invoke-id (:emits node-data)))
+                      drawable-children (filter #(and (contains? nodes %)
+                                                      (:node (get nodes %)))
+                                                emitted-ids)]
+                  (recur (into remaining drawable-children)
+                         (conj visited current-id))))))))))
+
 (defn get-graph-page!!
   [system {:keys [module-id agent-name invoke-id]}]
   (let [client (get-client system module-id agent-name)]
@@ -129,8 +158,12 @@
                                   [MAP-VALS :feedback :actions MAP-KEYS]
                                   name)))
 
-            agent-is-complete? (boolean (or (:finish-time-millis summary-info)
-                                            (:result summary-info)))]
+            agent-summary-complete? (boolean (or (:finish-time-millis summary-info)
+                                                 (:result summary-info)))
+            graph-complete? (and (seq cleaned-nodes)
+                                 root-invoke-id
+                                 (trace-graph-complete? cleaned-nodes root-invoke-id))
+            agent-is-complete? (and agent-summary-complete? graph-complete?)]
 
         {:is-complete agent-is-complete?
          :nodes cleaned-nodes

--- a/src/cljs/com/rpl/agent_o_rama/ui/events.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/events.cljs
@@ -40,13 +40,15 @@
   (fn [{:keys [storage-key value]}]
     (write-local-storage storage-key value)))
 
-(defn- graph-has-in-progress-nodes? [db invoke-id]
+(defn graph-has-in-progress-nodes?
+  [db invoke-id]
   (some (fn [node-data]
           (and (:start-time-millis node-data)
                (not (:finish-time-millis node-data))))
         (vals (get-in db [:invocations-data invoke-id :graph :nodes] {}))))
 
-(defn- should-schedule-poll? [db invoke-id page-is-complete]
+(defn should-schedule-poll?
+  [db invoke-id page-is-complete]
   (or (not page-is-complete)
       (graph-has-in-progress-nodes? db invoke-id)))
 

--- a/src/cljs/com/rpl/agent_o_rama/ui/events.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/events.cljs
@@ -1,12 +1,61 @@
 (ns com.rpl.agent-o-rama.ui.events
   (:require [com.rpl.agent-o-rama.ui.rpc :as rpc]
             [com.rpl.agent-o-rama.ui.forms :as forms]
+            [com.rpl.agent-o-rama.ui.invocations.subs :as inv-subs]
             [com.rpl.agent-o-rama.impl.ui.rpc.invocations :as rpc-invocations]
             [com.rpl.agent-o-rama.impl.ui.rpc.datasets :as rpc-datasets]
             [com.rpl.agent-o-rama.impl.ui.rpc.config :as rpc-config]
             [re-frame.core :as rf]
             [re-frame.db :as rdb]
             [clojure.string :as str]))
+
+(def ^:private poll-timeout-ids (atom {}))
+
+(defn- read-local-storage [key default]
+  (try
+    (let [item (js/localStorage.getItem key)]
+      (if (some? item) (js/JSON.parse item) default))
+    (catch js/Error _ default)))
+
+(defn- write-local-storage [key value]
+  (try
+    (js/localStorage.setItem key (js/JSON.stringify (clj->js value)))
+    (catch js/Error e
+      (.error js/console "Error saving to localStorage:" e))))
+
+(rf/reg-fx :invocation/poll-schedule
+  (fn [{:keys [invoke-id delay-ms dispatch-event]}]
+    (when-let [old-id (get @poll-timeout-ids invoke-id)]
+      (js/clearTimeout old-id))
+    (let [timeout-id (js/setTimeout #(rf/dispatch dispatch-event) delay-ms)]
+      (swap! poll-timeout-ids assoc invoke-id timeout-id))))
+
+(rf/reg-fx :invocation/poll-cancel
+  (fn [invoke-id]
+    (when-let [timeout-id (get @poll-timeout-ids invoke-id)]
+      (js/clearTimeout timeout-id)
+      (swap! poll-timeout-ids dissoc invoke-id))))
+
+(rf/reg-fx :invocation/persist-ui-preference
+  (fn [{:keys [storage-key value]}]
+    (write-local-storage storage-key value)))
+
+(defn- graph-has-in-progress-nodes? [db invoke-id]
+  (some (fn [node-data]
+          (and (:start-time-millis node-data)
+               (not (:finish-time-millis node-data))))
+        (vals (get-in db [:invocations-data invoke-id :graph :nodes] {}))))
+
+(defn- should-schedule-poll? [db invoke-id page-is-complete]
+  (or (not page-is-complete)
+      (graph-has-in-progress-nodes? db invoke-id)))
+
+(defn- init-invocation-ui-from-storage [db invoke-id]
+  (let [ui-path (inv-subs/invocation-ui-path invoke-id)
+        trace-mode (read-local-storage "invocation-trace-view-mode" "graph")
+        sidebar-width (read-local-storage "graph-sidebar-width" 320)]
+    (update-in db ui-path merge {:trace-view-mode trace-mode
+                                 :sidebar-width sidebar-width})))
 
 ;; Orchestration events that perform side-effects (HTTP RPC),
 ;; keeping React components pure.
@@ -140,11 +189,29 @@
              (assoc :current-invocation {:invoke-id invoke-id
                                          :module-id module-id
                                          :agent-name agent-name})
-             (assoc-in [:invocations-data invoke-id :status] :loading))
+             (assoc-in [:invocations-data invoke-id :status] :loading)
+             (init-invocation-ui-from-storage invoke-id))
+     :fx [[:invocation/poll-cancel invoke-id]]
      :dispatch [:invocation/fetch-graph-page
                 {:invoke-id invoke-id
                  :module-id module-id
                  :agent-name agent-name}]}))
+
+(rf/reg-event-fx :invocation/set-trace-view-mode
+  (fn [{:keys [db]} [_ invoke-id mode]]
+    {:db (assoc-in db (conj (inv-subs/invocation-ui-path invoke-id) :trace-view-mode) mode)
+     :fx [[:invocation/persist-ui-preference {:storage-key "invocation-trace-view-mode"
+                                            :value mode}]]}))
+
+(rf/reg-event-fx :invocation/set-sidebar-width
+  (fn [{:keys [db]} [_ invoke-id width]]
+    {:db (assoc-in db (conj (inv-subs/invocation-ui-path invoke-id) :sidebar-width) width)
+     :fx [[:invocation/persist-ui-preference {:storage-key "graph-sidebar-width"
+                                            :value width}]]}))
+
+(rf/reg-event-db :invocation/select-node
+  (fn [db [_ invoke-id node-id]]
+    (assoc-in db (conj (inv-subs/invocation-ui-path invoke-id) :selected-node-id) node-id)))
 
 (rf/reg-event-fx :invocation/fetch-graph-page
   (fn [_ [_ {:keys [invoke-id module-id agent-name] :as current-invocation}]]
@@ -182,33 +249,44 @@
                            (and (not (seq new-nodes-map)) (contains? page-data :is-complete))
                            (assoc-in db-after-summary [:invocations-data invoke-id :is-complete] is-complete)
 
-                           :else db-after-summary)]
-      (when-not is-complete
-        (js/setTimeout
-         (fn []
-           (when-not (get-in @rdb/app-db [:invocations-data invoke-id :is-complete])
-             (println "[POLLING-SIMPLIFIED] Polling for updates...")
-             (rf/dispatch [:invocation/fetch-graph-page current-invocation])))
-         1000))
-      {:db db-after-graph})))
+                           :else db-after-summary)
+          continue-poll? (should-schedule-poll? db-after-graph invoke-id is-complete)]
+      (when continue-poll?
+        (println "[POLLING] Scheduling poll for" invoke-id
+                 (if is-complete "(drain: in-progress nodes remain)" "")))
+      {:db db-after-graph
+       :fx (when continue-poll?
+             [[:invocation/poll-schedule
+               {:invoke-id invoke-id
+                :delay-ms 1000
+                :dispatch-event [:invocation/poll-tick current-invocation]}]])})))
 
-(rf/reg-event-db :invocation/cleanup
-  (fn [db [_ _]]
-    (-> db
-        (assoc-in [:ui :changed-nodes] {})
-        (assoc-in [:ui :selected-node-id] nil)
-        (assoc-in [:ui :forking-mode?] false)
-        (assoc-in [:ui :active-tab] :info)
-        (assoc-in [:ui :hitl :responses] {}))))
+(rf/reg-event-fx :invocation/poll-tick
+  (fn [{:keys [db]} [_ current-invocation]]
+    (let [{:keys [invoke-id]} current-invocation
+          still-active? (= invoke-id (get-in db [:current-invocation :invoke-id]))]
+      (if still-active?
+        {:dispatch [:invocation/fetch-graph-page current-invocation]}
+        {:fx [[:invocation/poll-cancel invoke-id]]}))))
+
+(rf/reg-event-fx :invocation/cleanup
+  (fn [{:keys [db]} [_ {:keys [invoke-id]}]]
+    {:db (-> db
+             (update-in [:ui :invocations] dissoc invoke-id)
+             (update-in [:invocations-data] dissoc invoke-id)
+             (assoc-in [:ui :active-tab] :info)
+             (assoc-in [:ui :hitl :responses] {}))
+     :fx [[:invocation/poll-cancel invoke-id]]}))
 
 (rf/reg-event-db :ui/clear-fork-state
-  (fn [db _]
-    (-> db
-        (assoc-in [:ui :changed-nodes] {})
-        (assoc-in [:ui :selected-node-id] nil)
-        (assoc-in [:ui :forking-mode?] false)
-        (assoc-in [:ui :active-tab] :info)
-        (assoc-in [:ui :hitl :responses] {}))))
+  (fn [db [_ invoke-id]]
+    (let [ui-path (inv-subs/invocation-ui-path invoke-id)]
+      (-> db
+          (assoc-in (conj ui-path :changed-nodes) {})
+          (assoc-in (conj ui-path :selected-node-id) nil)
+          (assoc-in (conj ui-path :forking-mode?) false)
+          (assoc-in [:ui :active-tab] :info)
+          (assoc-in [:ui :hitl :responses] {})))))
 
 (rf/reg-event-fx :hitl/submit
   (fn [{:keys [db]} [_ {:keys [module-id agent-name invoke-id request response]}]]

--- a/src/cljs/com/rpl/agent_o_rama/ui/invocations/detail.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/invocations/detail.cljs
@@ -4,12 +4,13 @@
    [uix.re-frame :refer [use-subscribe]]
    [com.rpl.agent-o-rama.ui.re-frame :as aor-rf]
    [uix.core :as uix :refer [$ defui]]
-   [com.rpl.agent-o-rama.ui.events] ;; Load event handlers
+   [com.rpl.agent-o-rama.ui.events]
+   [com.rpl.agent-o-rama.ui.invocations.subs]
    [com.rpl.agent-o-rama.ui.invocations.graph-view :as view]
+   [com.rpl.agent-o-rama.ui.invocations.subs :as inv-subs]
    [com.rpl.agent-o-rama.ui.rpc :as rpc]
    [com.rpl.agent-o-rama.impl.ui.rpc.invocations :as rpc-invocations]
    [com.rpl.agent-o-rama.ui.common :as common]
-   [com.rpl.specter :as s]
    [reitit.frontend.easy :as rfe]))
 
 (defui invocation-page []
@@ -17,72 +18,49 @@
         query-params (use-subscribe [::aor-rf/get-in [:route :query-params]])
         node-query-param (:node query-params)
 
-        invocation-state (use-subscribe [::aor-rf/get-in [:invocations-data invoke-id]])
+        invocation-state (use-subscribe [:invocation/state invoke-id])
+        graph-data (use-subscribe [:invocation/graph-data invoke-id])
+        selected-node-id (use-subscribe [:invocation/selected-node-id invoke-id])
+        changed-nodes (use-subscribe [:invocation/changed-nodes invoke-id])
+        root-invoke-id (use-subscribe [:invocation/root-invoke-id invoke-id])
 
-        {:keys [status graph summary is-complete implicit-edges
-                root-invoke-id task-id forks fork-of error]}
+        {:keys [status summary error task-id forks fork-of]}
         (or invocation-state {:status :loading})
 
-        ;; Extract nested data
-        nodes (:nodes graph)
-        real-edges (:edges graph)
         summary-data summary
 
-        ;; UI state subscriptions
-        selected-node-id (use-subscribe [::aor-rf/get-in [:ui :selected-node-id]])
-        forking-mode? (use-subscribe [::aor-rf/get-in [:ui :forking-mode?]])
-        changed-nodes (use-subscribe [::aor-rf/get-in [:ui :changed-nodes]])
-
-        ;; Transform nodes to graph-data format
-        graph-data (when nodes
-                     (into {}
-                           (for [[node-id node-data] nodes]
-                             [node-id node-data])))
-
-        ;; 2. The single useEffect to initiate data loading
         _ (uix/use-effect
            (fn []
              (when (and invoke-id module-id agent-name)
                (rf/dispatch [:invocation/start-graph-loading
-                                {:invoke-id invoke-id
-                                 :module-id module-id
-                                 :agent-name agent-name}]))
-             ;; Cleanup function
+                             {:invoke-id invoke-id
+                              :module-id module-id
+                              :agent-name agent-name}]))
              (fn []
                (rf/dispatch [:invocation/cleanup {:invoke-id invoke-id}])))
            [invoke-id module-id agent-name])
 
-        ;; Auto-select node when graph data loads
-        ;; Priority: 1) node from query param, 2) root node, 3) any first node
         _ (uix/use-effect
            (fn []
              (when (and graph-data (not selected-node-id))
-               (let [;; Parse node from query param: format is "task-id-node-invoke-id"
-                     ;; We need to extract the node-invoke-id (UUID) part
-                     node-uuid (when node-query-param
+               (let [node-uuid (when node-query-param
                                  (let [parts (clojure.string/split node-query-param #"-" 2)]
                                    (when (= 2 (count parts))
                                      (try
                                        (uuid (second parts))
-                                       (catch js/Error e
-                                         nil)))))
-                     ;; Check if the parsed node UUID exists in the graph
+                                       (catch js/Error _ nil)))))
                      node-from-query (when (and node-uuid (get graph-data node-uuid))
                                        node-uuid)
-                     ;; Fallback to root node
                      node-to-select (or node-from-query root-invoke-id)]
                  (when node-to-select
-                   (rf/dispatch [:db/set-value [:ui :selected-node-id] node-to-select])))))
-           [graph-data root-invoke-id selected-node-id node-query-param])
+                   (rf/dispatch [:invocation/select-node invoke-id node-to-select])))))
+           [graph-data root-invoke-id selected-node-id node-query-param invoke-id])
 
-        ;; 3. Polling effect removed in favor of unified streaming loop in events
-
-        ;; 4. Define callback functions that dispatch events
         handle-select-node (fn [node-id]
-                             (rf/dispatch [:db/set-value [:ui :selected-node-id] node-id]))
+                             (rf/dispatch [:invocation/select-node invoke-id node-id]))
 
         handle-execute-fork (fn []
-                              (when (not (empty? changed-nodes))
+                              (when (seq changed-nodes)
                                 (-> (rpc/call ::rpc-invocations/execute-fork!!
                                               {:module-id module-id
                                                :agent-name agent-name
@@ -90,72 +68,60 @@
                                                :changed-nodes changed-nodes})
                                     (.then (fn [data]
                                              (let [{:keys [task-id agent-invoke-id]} data]
-                                               (rf/dispatch [:ui/clear-fork-state])
+                                               (rf/dispatch [:ui/clear-fork-state invoke-id])
                                                (rfe/push-state :agent/invocation-detail
-                                                               {:module-id module-id :agent-name agent-name
+                                                               {:module-id module-id
+                                                                :agent-name agent-name
                                                                 :invoke-id (str task-id "-" agent-invoke-id)}))))
                                     (.catch (fn [err]
-                                              (js/console.error "Fork failed:" (if (map? err) (or (:error err) (str err)) (str err))))))))
+                                              (js/console.error "Fork failed:"
+                                                                (if (map? err) (or (:error err) (str err)) (str err))))))))
 
         handle-clear-fork (fn []
-                            (rf/dispatch [:ui/clear-fork-state]))
+                            (rf/dispatch [:ui/clear-fork-state invoke-id]))
 
         handle-change-node-input (fn [node-id new-input]
-                                   (rf/dispatch [:db/update-value [:ui :changed-nodes] #(assoc % node-id new-input)]))
+                                   (rf/dispatch [:db/update-value
+                                                 (conj (inv-subs/invocation-ui-path invoke-id) :changed-nodes)
+                                                 #(assoc % node-id new-input)]))
 
         handle-remove-node-change (fn [node-id]
-                                    (rf/dispatch [:db/update-value [:ui :changed-nodes] #(dissoc % node-id)]))
+                                    (rf/dispatch [:db/update-value
+                                                  (conj (inv-subs/invocation-ui-path invoke-id) :changed-nodes)
+                                                  #(dissoc % node-id)]))
 
         handle-toggle-forking-mode (fn []
-                                     (rf/dispatch [:ui/toggle-forking-mode]))
+                                     (rf/dispatch [:ui/toggle-forking-mode invoke-id]))
 
-        handle-paginate-node (fn [missing-node-id] :todo)
+        handle-paginate-node (fn [_missing-node-id] :todo)]
 
-        ;; Prepare the data for the view
-        view-props {:module-id module-id
-                    :agent-name agent-name
-                    :invoke-id invoke-id
-                    :task-id task-id
-                    :root-invoke-id root-invoke-id
-                    :forks forks
-                    :fork-of fork-of
-                    :graph-data graph-data
-                    :real-edges (or real-edges []) ; NEW: Pass pre-processed real edges
-                    :summary-data summary-data
-                    :implicit-edges (or implicit-edges [])
-                    :is-complete is-complete
-                    :is-live (not is-complete)
-                    :connected? true
-                    :selected-node-id selected-node-id
-                    :forking-mode? forking-mode?
-                    :changed-nodes changed-nodes
-                    :on-select-node handle-select-node
-                    :on-execute-fork handle-execute-fork
-                    :on-clear-fork handle-clear-fork
-                    :on-change-node-input handle-change-node-input
-                    :on-remove-node-change handle-remove-node-change
-                    :on-toggle-forking-mode handle-toggle-forking-mode
-                    :on-paginate-node handle-paginate-node}]
-
-    ;; 5. Render based on explicit status and connection state
     (cond
-      ;; Explicit loading state
       (= status :loading)
       ($ :div.flex.items-center.justify-center.p-8
          ($ common/spinner {:size :medium})
          ($ :div.text-gray-500.ml-2 "Loading invocation data..."))
 
-      ;; Explicit error state
       (= status :error)
       ($ :div.flex.items-center.justify-center.p-8
-         (.log js/console "error" error)
-         ($ :div.text-red-500 "Failed to load invocation: " (or (when error (str error)) "Unknown error - module or agent may not be loaded")))
+         ($ :div.text-red-500 "Failed to load invocation: "
+            (or (when error (str error)) "Unknown error - module or agent may not be loaded")))
 
-      ;; Success state but no graph data yet (still loading graph)
       (and (= status :success) (not graph-data))
       ($ :div.flex.items-center.justify-center.p-8
          ($ common/spinner {:size :medium})
          ($ :div.text-gray-500.ml-2 "Loading graph data..."))
 
       :else
-      ($ view/graph-view view-props))))
+      ($ view/graph-view {:module-id module-id
+                          :agent-name agent-name
+                          :invoke-id invoke-id
+                          :task-id task-id
+                          :forks forks
+                          :fork-of fork-of
+                          :on-select-node handle-select-node
+                          :on-execute-fork handle-execute-fork
+                          :on-clear-fork handle-clear-fork
+                          :on-change-node-input handle-change-node-input
+                          :on-remove-node-change handle-remove-node-change
+                          :on-toggle-forking-mode handle-toggle-forking-mode
+                          :on-paginate-node handle-paginate-node}))))

--- a/src/cljs/com/rpl/agent_o_rama/ui/invocations/gantt_trace.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/invocations/gantt_trace.cljs
@@ -68,7 +68,9 @@
             children-map
             agg-ids)))
 
-(defn- gantt-children-map [graph-data real-edges implicit-edges]
+(defn gantt-children-map
+  "Build parent→children map for Gantt rows, collapsing duplicate agg fan-in edges."
+  [graph-data real-edges implicit-edges]
   (let [edges (concat (or real-edges []) (or implicit-edges []))
         raw (children-by-parent edges)]
     (collapse-fan-in-agg-children graph-data edges raw)))
@@ -91,7 +93,7 @@
                          :label (str (or (:node data) "?"))
                          :data data}
                     child-rows (when-not (contains? collapsed nid)
-                                 (mapcat walk children))]
+                                 (mapcat #(walk % (inc depth)) children))]
                 (cons row child-rows))))]
     (vec (walk root-id 0))))
 

--- a/src/cljs/com/rpl/agent_o_rama/ui/invocations/gantt_trace.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/invocations/gantt_trace.cljs
@@ -2,6 +2,7 @@
   "Row / timeline (Gantt-style) visualization of agent node invocations."
   (:require
    [uix.core :as uix :refer [defui $]]
+   [uix.re-frame :refer [use-subscribe]]
    ["react" :refer [useState useMemo useEffect]]
    [com.rpl.agent-o-rama.ui.invocations.graph-node :as gn]
    [com.rpl.agent-o-rama.ui.common :as common]))
@@ -274,3 +275,20 @@
          (when (empty? rows)
            ($ :div {:className "p-8 text-center text-sm text-gray-500"}
               "No timed node data to display yet.")))))))
+
+(defui gantt-trace-view-connected
+  "Subscribes to re-frame graph data for the given invocation."
+  [{:keys [invoke-id on-select-node]}]
+  (let [graph-data (use-subscribe [:invocation/graph-data invoke-id])
+        real-edges (use-subscribe [:invocation/real-edges invoke-id])
+        implicit-edges (use-subscribe [:invocation/implicit-edges invoke-id])
+        root-invoke-id (use-subscribe [:invocation/root-invoke-id invoke-id])
+        selected-node-id (use-subscribe [:invocation/selected-node-id invoke-id])
+        is-complete (use-subscribe [:invocation/is-complete invoke-id])]
+    ($ gantt-trace-view {:graph-data graph-data
+                         :real-edges real-edges
+                         :implicit-edges implicit-edges
+                         :root-invoke-id root-invoke-id
+                         :selected-node-id selected-node-id
+                         :on-select-node on-select-node
+                         :is-complete is-complete})))

--- a/src/cljs/com/rpl/agent_o_rama/ui/invocations/graph_layout.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/invocations/graph_layout.cljs
@@ -1,0 +1,63 @@
+(ns com.rpl.agent-o-rama.ui.invocations.graph-layout
+  "Dagre layout and graph traversal helpers for invocation trace views."
+  (:require
+   [com.rpl.agent-o-rama.ui.invocations.graph-node :as gn]
+   ["@dagrejs/dagre" :as Dagre]))
+
+(defn process-graph-data
+  "Applies Dagre layout to pre-processed nodes and edges."
+  [nodes-map real-edges implicit-edges]
+  (let [g (new (.. Dagre -graphlib -Graph))
+
+        nodes (->> nodes-map
+                   (map (fn [[id data]]
+                          {:id (str id)
+                           :type "custom"
+                           :draggable false
+                           :data (assoc data
+                                        :label (str (:node data))
+                                        :node-id id)})))
+
+        all-edges (concat real-edges implicit-edges)]
+
+    (.setDefaultEdgeLabel ^js g (fn [] #js {}))
+    (.setGraph ^js g #js {})
+
+    (doseq [edge all-edges] (.setEdge ^js g (:source edge) (:target edge)))
+    (doseq [node nodes]
+      (.setNode ^js g (:id node) (clj->js (merge node {:width 170 :height 40}))))
+
+    (Dagre/layout g)
+
+    (let [nodes-with-layout (for [node nodes
+                                  :let [position (.node g (:id node))]]
+                              (assoc node :position position))]
+      {:nodes nodes-with-layout
+       :edges all-edges})))
+
+(defn find-downstream-nodes
+  "Find all nodes downstream from the given set of modified node IDs."
+  [graph-data modified-node-ids]
+  (let [get-downstream-from-node (fn [start-node-id]
+                                   (loop [to-visit #{start-node-id}
+                                          visited #{}
+                                          downstream #{}]
+                                     (if (empty? to-visit)
+                                       downstream
+                                       (let [current (first to-visit)
+                                             remaining (disj to-visit current)]
+                                         (if (visited current)
+                                           (recur remaining visited downstream)
+                                           (let [node-data (gn/graph-node-data graph-data current)
+                                                 emitted-ids (set (map :invoke-id (:emits node-data)))
+                                                 new-downstream (if (= current start-node-id)
+                                                                  downstream
+                                                                  (conj downstream current))
+                                                 new-to-visit (into remaining emitted-ids)]
+                                             (recur new-to-visit
+                                                    (conj visited current)
+                                                    new-downstream)))))))]
+    (reduce (fn [all-downstream modified-node-id]
+              (into all-downstream (get-downstream-from-node modified-node-id)))
+            #{}
+            modified-node-ids)))

--- a/src/cljs/com/rpl/agent_o_rama/ui/invocations/graph_status.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/invocations/graph_status.cljs
@@ -1,0 +1,38 @@
+(ns com.rpl.agent-o-rama.ui.invocations.graph-status
+  (:require
+   [uix.core :refer [defui $]]
+   [com.rpl.agent-o-rama.ui.common :as common]
+   ["@heroicons/react/24/outline" :refer [ExclamationTriangleIcon]]))
+
+(defui node-status-bar
+  [{:keys [in-progress? is-stuck? has-changes has-human-request has-exceptions has-result]}]
+  (let [indicators (cond-> []
+                     (and in-progress? (not is-stuck?))
+                     (conj {:type :spinner :title "Processing..."})
+                     is-stuck?
+                     (conj {:type :stuck :title "Node terminated due to max retries"})
+                     has-changes
+                     (conj {:type :changed :title "Modified for fork"})
+                     has-human-request
+                     (conj {:type :human :title "Awaiting human input"})
+                     (and has-exceptions (not is-stuck?))
+                     (conj {:type :exception :title "Has exceptions"})
+                     has-result
+                     (conj {:type :success :title "Completed successfully"}))]
+    (when (seq indicators)
+      ($ :div {:className (common/cn "absolute -top-1 -right-1 flex items-center gap-0.5 rounded-full px-0.5 py-0.5 bg-white border border-gray-200")}
+         (for [{:keys [type title]} indicators]
+           ($ :div {:key type
+                    :className (common/cn "w-3 h-3 flex items-center justify-center")
+                    :title title}
+              (case type
+                :spinner ($ common/spinner {:size :small})
+                :stuck ($ :div {:className (common/cn "w-3 h-3 bg-red-500 rounded-full flex items-center justify-center")}
+                          ($ :svg {:className (common/cn "w-2 h-2 text-white") :fill "none" :viewBox "0 0 24 24" :stroke "currentColor"}
+                             ($ :path {:strokeLinecap "round" :strokeLinejoin "round" :strokeWidth 3 :d "M6 18L18 6M6 6l12 12"})))
+                :changed ($ :div {:className (common/cn "w-3 h-3 bg-orange-400 rounded-full")})
+                :human ($ :div {:className (common/cn "w-3 h-3 flex items-center justify-center text-xs")} "🙋")
+                :exception ($ :div {:className (common/cn "w-3 h-3 bg-yellow-500 rounded-full flex items-center justify-center")}
+                              ($ ExclamationTriangleIcon {:className "w-2 h-2 text-white"}))
+                :success ($ :div {:className (common/cn "w-3 h-3 bg-green-500 rounded-full")})
+                nil)))))))

--- a/src/cljs/com/rpl/agent_o_rama/ui/invocations/graph_view.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/invocations/graph_view.cljs
@@ -23,10 +23,9 @@
    [com.rpl.agent-o-rama.impl.ui.rpc.invocations :as rpc-invocations]
    [com.rpl.agent-o-rama.ui.invocations.graph-node :as gn]
    [com.rpl.agent-o-rama.ui.invocations.gantt-trace :as gantt]
+   [com.rpl.agent-o-rama.ui.invocations.react-flow-view :as react-flow]
 
    ["react" :refer [useState useCallback useEffect]]
-   ["@xyflow/react" :refer [ReactFlow Background Controls useNodesState useEdgesState Handle MiniMap]]
-   ["@dagrejs/dagre" :as Dagre]
    ["@heroicons/react/24/outline" :refer [ExclamationTriangleIcon ArrowPathIcon ArrowTopRightOnSquareIcon PencilIcon XMarkIcon]]))
 
 (defui ExceptionDetailModal [{:keys [title content]}]
@@ -54,66 +53,6 @@
 (def starter-node? gn/starter-node?)
 
 (def agg-node? gn/agg-node?)
-
-(defui node-status-bar
-  "Renders a horizontal status bar showing all active node states.
-   Props:
-   - :in-progress? - Node is currently processing
-   - :is-stuck? - Node terminated due to max retries
-   - :has-changes - Node has been modified for forking
-   - :has-human-request - Node is waiting for human input
-   - :has-exceptions - Node has exceptions
-   - :has-result - Node completed successfully"
-  [{:keys [in-progress? is-stuck? has-changes has-human-request has-exceptions has-result]}]
-  (let [;; Collect all active status indicators
-        indicators (cond-> []
-                     ;; In-progress or stuck
-                     (and in-progress? (not is-stuck?))
-                     (conj {:type :spinner
-                            :title "Processing..."})
-
-                     is-stuck?
-                     (conj {:type :stuck
-                            :title "Node terminated due to max retries"})
-
-                     ;; Has changes (forking mode)
-                     has-changes
-                     (conj {:type :changed
-                            :title "Modified for fork"})
-
-                     ;; Human request
-                     has-human-request
-                     (conj {:type :human
-                            :title "Awaiting human input"})
-
-                     ;; Exceptions (only if not stuck)
-                     (and has-exceptions (not is-stuck?))
-                     (conj {:type :exception
-                            :title "Has exceptions"})
-
-                     ;; Successful result
-                     has-result
-                     (conj {:type :success
-                            :title "Completed successfully"}))]
-
-    ;; Render the status bar if there are any indicators
-    (when (seq indicators)
-      ($ :div {:className (common/cn "absolute -top-1 -right-1 flex items-center gap-0.5 rounded-full px-0.5 py-0.5 bg-white border border-gray-200")}
-         (for [{:keys [type title]} indicators]
-           ($ :div {:key type
-                    :className (common/cn "w-3 h-3 flex items-center justify-center")
-                    :title title}
-              (case type
-                :spinner ($ common/spinner {:size :small})
-                :stuck ($ :div {:className (common/cn "w-3 h-3 bg-red-500 rounded-full flex items-center justify-center")}
-                          ($ :svg {:className (common/cn "w-2 h-2 text-white") :fill "none" :viewBox "0 0 24 24" :stroke "currentColor"}
-                             ($ :path {:strokeLinecap "round" :strokeLinejoin "round" :strokeWidth 3 :d "M6 18L18 6M6 6l12 12"})))
-                :changed ($ :div {:className (common/cn "w-3 h-3 bg-orange-400 rounded-full")})
-                :human ($ :div {:className (common/cn "w-3 h-3 flex items-center justify-center text-xs")} "🙋")
-                :exception ($ :div {:className (common/cn "w-3 h-3 bg-yellow-500 rounded-full flex items-center justify-center")}
-                              ($ ExclamationTriangleIcon {:className "w-2 h-2 text-white"}))
-                :success ($ :div {:className (common/cn "w-3 h-3 bg-green-500 rounded-full")})
-                nil)))))))
 
 (defui expandable-item-component [{:keys [item color title truncate-length]
                                    :or {truncate-length 50}}]
@@ -454,7 +393,7 @@
            ($ :div {:className "mt-2 text-xs text-blue-500"}
               (str (count chunks) " chunk" (when (not= (count chunks) 1) "s") " received")))))))
 
-(defui node-emits-panel [{:keys [emits graph-data flow-nodes on-select-node on-paginate-node]}]
+(defui node-emits-panel [{:keys [emits graph-data on-select-node on-paginate-node]}]
   (when (and emits (> (count emits) 0))
     ($ :div {:className "mt-4 bg-indigo-50 p-3 rounded-md"}
        ($ :div {:className "text-sm font-medium text-indigo-700 mb-2"}
@@ -471,13 +410,8 @@
                        :onClick (fn [e]
                                   (.stopPropagation e)
                                   (if is-loaded
-                                    ;; Find and select the loaded node
-                                    (let [nodes (js->clj flow-nodes :keywordize-keys true)
-                                          target-node (->> nodes
-                                                           (filter #(= (-> % :data :node-id) (:invoke-id emit)))
-                                                           first)]
-                                      (when (and target-node on-select-node)
-                                        (on-select-node (:invoke-id emit))))
+                                    (when on-select-node
+                                      (on-select-node (:invoke-id emit)))
                                     ;; Load the unloaded node
                                     (when on-paginate-node
                                       (on-paginate-node emit-id))))}
@@ -493,7 +427,7 @@
 
 (defui node-details-info-panel [{:keys [data hr hr-invoke-id hitl-response submitting? module-id agent-name invoke-id
                                         node-id node-name result exceptions start-time finish-time duration input
-                                        emits graph-data flow-nodes on-select-node on-paginate-node
+                                        emits graph-data on-select-node on-paginate-node
                                         agent-invoke-id]}]
   (let [raw-node-data (graph-node-data graph-data node-id)]
     ($ :<>
@@ -544,7 +478,6 @@
 
        ($ node-emits-panel {:emits emits
                             :graph-data graph-data
-                            :flow-nodes flow-nodes
                             :on-select-node on-select-node
                             :on-paginate-node on-paginate-node})
 
@@ -552,10 +485,9 @@
                              :finish-time finish-time
                              :duration duration}))))
 
-(defui selected-node-component [{:keys [selected-node graph-data on-paginate-node on-select-node flow-nodes module-id agent-name invoke-id]}]
-  (let [data (when selected-node
-               (js->clj (aget selected-node "data") :keywordize-keys true))
-        node-id (:node-id data)
+(defui selected-node-component [{:keys [selected-node-data graph-data on-paginate-node on-select-node module-id agent-name invoke-id]}]
+  (let [data selected-node-data
+        node-id (when data (:node-id data))
         node-task-id (:agent-task-id data)
         node-name (:node data)
         input (:input data)
@@ -588,7 +520,7 @@
          (rf/dispatch [:db/set-value [:ui :node-details :active-tab] :info])))
      [active-tab])
 
-    (when selected-node
+    (when selected-node-data
       ($ :div {:className (common/cn "mt-6 bg-white shadow-lg rounded-lg border border-gray-200 max-w-4xl")
                :data-id "node-invoke-details-panel"}
          ;; Tab header
@@ -631,7 +563,6 @@
                   :input input
                   :emits emits
                   :graph-data graph-data
-                  :flow-nodes flow-nodes
                   :on-select-node on-select-node
                   :on-paginate-node on-paginate-node})
 
@@ -650,9 +581,8 @@
               ;; Default case
               nil))))))
 
-(defui forking-input-component [{:keys [selected-node changed-nodes on-change-node-input affected-nodes]}]
-  (let [data (when selected-node
-               (js->clj (aget selected-node "data") :keywordize-keys true))
+(defui forking-input-component [{:keys [selected-node-data changed-nodes on-change-node-input affected-nodes]}]
+  (let [data selected-node-data
         node-id (:node-id data)
         node-name (:node data)
         original-input (:input data)
@@ -672,15 +602,13 @@
     ;; Update input text when selected node changes
     (uix/use-effect
      (fn []
-       (when selected-node
-         (let [data (js->clj (aget selected-node "data") :keywordize-keys true)
-               node-id (:node-id data)
-               original-input (:input data)
+       (when selected-node-data
+         (let [original-input (:input selected-node-data)
                current-input (get changed-nodes node-id (to-pretty-json original-input))]
            (set-input-text current-input))))
-     [selected-node changed-nodes])
+     [selected-node-data changed-nodes node-id])
 
-    (when selected-node
+    (when selected-node-data
       ($ :div {:className (common/cn "mt-6 bg-white shadow-lg rounded-lg border border-gray-200 max-w-4xl")}
          ($ :div {:className "p-6"}
             ($ :div {:className "mb-4"}
@@ -976,7 +904,7 @@
                                               :agent-name agent-name}]))
                           :is-live? (not (:finish-time-millis summary-data))}))))
 
-(defui fork-panel [{:keys [changed-nodes graph-data affected-nodes flow-nodes on-select-node on-remove-node-change on-execute-fork on-clear-fork]}]
+(defui fork-panel [{:keys [changed-nodes graph-data affected-nodes on-select-node on-remove-node-change on-execute-fork on-clear-fork]}]
   (if (empty? changed-nodes)
     ($ :div {:className "text-gray-500 text-center py-8"
              :data-id "fork-empty-state"}
@@ -992,13 +920,8 @@
                   is-overridden (contains? affected-nodes node-id)
                   handle-select-node (fn [e]
                                        (.stopPropagation e)
-                                       ;; Find the corresponding flow node and select it
-                                       (let [nodes (js->clj flow-nodes :keywordize-keys true)
-                                             target-node (->> nodes
-                                                              (filter #(= (-> % :data :node-id) node-id))
-                                                              first)]
-                                         (when (and target-node on-select-node)
-                                           (on-select-node node-id))))]
+                                       (when on-select-node
+                                         (on-select-node node-id)))]
 
               ($ :div {:key node-id
                        :className (common/cn "border rounded-lg p-3 cursor-pointer hover:shadow-md transition-shadow"
@@ -1039,7 +962,7 @@
                       :onClick on-clear-fork}
              "Clear All Changes")))))
 
-(defui right-panel [{:keys [graph-data summary-data changed-nodes on-remove-node-change affected-nodes flow-nodes on-select-node on-execute-fork on-clear-fork forking-mode? on-toggle-forking-mode is-live
+(defui right-panel [{:keys [graph-data summary-data changed-nodes on-remove-node-change affected-nodes on-select-node on-execute-fork on-clear-fork forking-mode? on-toggle-forking-mode is-live
                             module-id agent-name task-id forks fork-of invoke-id sidebar-width on-sidebar-width-change]}]
   (let [;; Read tab from URL query params, default to :info
         query-params (use-subscribe [::aor-rf/get-in [:route :query-params]])
@@ -1154,134 +1077,35 @@
             :fork ($ fork-panel {:changed-nodes changed-nodes
                                  :graph-data graph-data
                                  :affected-nodes affected-nodes
-                                 :flow-nodes flow-nodes
                                  :on-select-node on-select-node
                                  :on-remove-node-change on-remove-node-change
                                  :on-execute-fork on-execute-fork
                                  :on-clear-fork on-clear-fork}))))))
 
-(defn process-graph-data
-  "Applies Dagre layout to pre-processed nodes and edges."
-  [nodes-map real-edges implicit-edges]
-  (let [g (new (.. Dagre -graphlib -Graph))
-
-        nodes (->> nodes-map
-                   (map (fn [[id data]]
-                          {:id (str id)
-                           :type "custom"
-                           :draggable false
-                           :data (assoc data
-                                        :label (str (:node data))
-                                        :node-id id)})))
-
-        all-edges (concat real-edges implicit-edges)]
-
-    (.setDefaultEdgeLabel ^js g (fn [] #js {}))
-    (.setGraph ^js g #js {})
-
-    (doseq [edge all-edges] (.setEdge ^js g (:source edge) (:target edge)))
-    (doseq [node nodes]
-      (.setNode ^js g (:id node) (clj->js (merge node {:width 170 :height 40}))))
-
-    (Dagre/layout g)
-
-    (let [nodes-with-layout (for [node nodes
-                                  :let [position (.node g (:id node))]]
-                              (assoc node :position position))]
-      {:nodes nodes-with-layout
-       :edges all-edges})))
-
-(defn find-downstream-nodes
-  "Find all nodes that are downstream from the given set of modified node IDs.
-   This includes nodes that are both modified AND downstream (overridden nodes)."
-  [graph-data modified-node-ids]
-  (let [;; For each modified node, find all nodes downstream from it
-        get-downstream-from-node (fn [start-node-id]
-                                   (loop [to-visit #{start-node-id}
-                                          visited #{}
-                                          downstream #{}]
-                                     (if (empty? to-visit)
-                                       downstream
-                                       (let [current (first to-visit)
-                                             remaining (disj to-visit current)]
-                                         (if (visited current)
-                                           (recur remaining visited downstream)
-                                           (let [node-data (graph-node-data graph-data current)
-                                                 emitted-ids (set (map :invoke-id (:emits node-data)))
-                                                 ;; Add emitted nodes to downstream (but not the starting node)
-                                                 new-downstream (if (= current start-node-id)
-                                                                  downstream
-                                                                  (conj downstream current))
-                                                 new-to-visit (into remaining emitted-ids)]
-                                             (recur new-to-visit
-                                                    (conj visited current)
-                                                    new-downstream)))))))]
-    ;; Collect downstream nodes from all modified nodes
-    (reduce (fn [all-downstream modified-node-id]
-              (into all-downstream (get-downstream-from-node modified-node-id)))
-            #{}
-            modified-node-ids)))
-
-(defui graph-view [{:keys [module-id agent-name invoke-id task-id
-                           forks fork-of root-invoke-id
-                           graph-data real-edges summary-data implicit-edges
-                           is-complete is-live connected?
-                           selected-node-id forking-mode? changed-nodes
-                           on-select-node on-execute-fork on-clear-fork
-                           on-change-node-input on-remove-node-change
-                           on-toggle-forking-mode on-paginate-node]}]
-  (let [;; Convert selected-node-id to actual node object when needed
-        [selected-node set-selected-node-internal] (uix/use-state nil)
-
-        [trace-view-mode set-trace-view-mode] (common/use-local-storage "invocation-trace-view-mode" "graph")
-
-        ;; Sidebar width state (default 320px)
-        [sidebar-width set-sidebar-width] (common/use-local-storage "graph-sidebar-width" 320)
-
-        affected-nodes (when forking-mode?
-                         (find-downstream-nodes graph-data (set (keys changed-nodes))))
-
-        ;; Use React Flow's state management hooks
-        [flow-nodes set-nodes on-nodes-change] (useNodesState (clj->js []))
-        [flow-edges set-edges on-edges-change] (useEdgesState (clj->js []))
-
-        ;; Update React Flow nodes/edges when graph data changes
-        _ (uix/use-effect
-           (fn []
-             (when (not (empty? graph-data))
-               (let [{:keys [nodes edges]} (process-graph-data graph-data (or real-edges []) (or implicit-edges []))]
-                 (println "Updating flow with nodes:" (count nodes) "and edges:" (count edges))
-                 (set-nodes (clj->js nodes))
-                 (set-edges (clj->js (for [edge edges]
-                                       (if (:implicit? edge)
-                                         (assoc edge :style #js {:strokeDasharray "5 5"
-                                                                 :stroke "#aaa"})
-                                         edge)))))))
-           [graph-data real-edges implicit-edges set-nodes set-edges])
-
-        ;; Update selected node when selected-node-id changes
-        _ (uix/use-effect
-           (fn []
-             (when selected-node-id
-               (let [nodes (js->clj flow-nodes :keywordize-keys true)
-                     target-node (->> nodes
-                                      (filter #(= (-> % :data :node-id) selected-node-id))
-                                      first)]
-                 (when target-node
-                   (set-selected-node-internal (clj->js target-node))))))
-           [selected-node-id flow-nodes])
-
-        ;; Use callbacks passed as props
-        handle-select-node-click (fn [node]
-                                   (when on-select-node
-                                     (let [node-data (js->clj (aget node "data") :keywordize-keys true)]
-                                       (on-select-node (:node-id node-data)))))]
-
+(defui graph-view
+  "Orchestrates trace visualization (graph / Gantt) and the right sidebar."
+  [{:keys [module-id agent-name invoke-id task-id forks fork-of
+           on-select-node on-execute-fork on-clear-fork
+           on-change-node-input on-remove-node-change
+           on-toggle-forking-mode on-paginate-node]}]
+  (let [graph-data (use-subscribe [:invocation/graph-data invoke-id])
+        summary-data (use-subscribe [:invocation/summary invoke-id])
+        trace-view-mode (use-subscribe [:invocation/trace-view-mode invoke-id])
+        sidebar-width (use-subscribe [:invocation/sidebar-width invoke-id])
+        selected-node-data (use-subscribe [:invocation/selected-node-data invoke-id])
+        changed-nodes (use-subscribe [:invocation/changed-nodes invoke-id])
+        forking-mode? (use-subscribe [:invocation/forking-mode? invoke-id])
+        affected-nodes (use-subscribe [:invocation/affected-nodes invoke-id])
+        is-complete (use-subscribe [:invocation/is-complete invoke-id])
+        is-live (not is-complete)
+        set-trace-view-mode! (fn [mode]
+                               (rf/dispatch [:invocation/set-trace-view-mode invoke-id mode]))
+        set-sidebar-width! (fn [width]
+                             (rf/dispatch [:invocation/set-sidebar-width invoke-id width]))]
     (if (empty? graph-data)
       ($ :div.flex.justify-center.items-center.py-8
          ($ :div.text-gray-500 "No graph data available"))
       ($ :<>
-         ;; Main content area with right margin for the stats panel
          ($ :div {:style {:marginRight (str sidebar-width "px")}
                   :data-id "agent-graph-panel"}
             ($ :div {:className "flex items-center gap-2 mb-2 px-1"}
@@ -1293,7 +1117,7 @@
                                                       "bg-white shadow text-gray-900"
                                                       "text-gray-600 hover:text-gray-900"))
                               :data-testid "trace-view-graph"
-                              :onClick #(set-trace-view-mode "graph")}
+                              :onClick #(set-trace-view-mode! "graph")}
                      "Graph")
                   ($ :button {:type "button"
                               :className (common/cn "px-2 py-1 rounded transition-colors"
@@ -1301,117 +1125,32 @@
                                                       "bg-white shadow text-gray-900"
                                                       "text-gray-600 hover:text-gray-900"))
                               :data-testid "trace-view-gantt"
-                              :onClick #(set-trace-view-mode "gantt")}
+                              :onClick #(set-trace-view-mode! "gantt")}
                      "Timeline")))
             (if (= trace-view-mode "gantt")
-              ($ gantt/gantt-trace-view {:graph-data graph-data
-                                         :real-edges real-edges
-                                         :implicit-edges implicit-edges
-                                         :root-invoke-id root-invoke-id
-                                         :selected-node-id selected-node-id
-                                         :on-select-node on-select-node
-                                         :is-complete is-complete})
-              ($ :div {:style {:width "100%" :height "500px"}}
-                 ($ ReactFlow {:nodes flow-nodes
-                             :edges flow-edges
-                             :onNodesChange on-nodes-change
-                             :onEdgesChange on-edges-change
-                             :proOptions (clj->js {:hideAttribution true})
-                             :nodeTypes (clj->js {"custom"
-                                                  (uix.core/as-react
-                                                   (fn [{:keys [data id]}]
-                                                     (let [data (js->clj data :keywordize-keys true)
-                                                           label (:label data)
-                                                           node-id (:node-id data)
-                                                           selected (= (when selected-node (aget selected-node "id")) id)
-                                                           has-changes (contains? changed-nodes node-id)
-                                                           is-affected (and forking-mode? (contains? affected-nodes node-id))
-                                                           ;; Check if node is in progress
-                                                           in-progress? (and (:start-time-millis data)
-                                                                             (not (:finish-time-millis data)))
-                                                           ;; NEW: Check if the node is stuck (in-progress but the whole agent has finished)
-                                                           is-stuck? (and in-progress? is-complete)
-                                                           base-classes (cond
-                                                                          is-affected
-                                                                          ["bg-gray-300" "text-gray-500" "border-2" "border-gray-400"]
-
-                                                                          has-changes
-                                                                          ["bg-orange-500" "text-white" "border-2" "border-orange-600"]
-
-                                                                          (agg-node? data)
-                                                                          ["bg-yellow-500" "text-white" "border-2" "border-yellow-600"]
-
-                                                                          (starter-node? data)
-                                                                          ["bg-green-500" "text-white" "border-2" "border-green-600"]
-
-                                                                          :else
-                                                                          ["bg-white" "text-gray-800" "border-2" "border-gray-300"])
-                                                           selection-classes (if selected
-                                                                               ["ring-4" "ring-blue-400" "ring-opacity-75" "shadow-2xl" "transform" "scale-105"]
-                                                                               ["shadow-lg"])
-                                                           common-classes ["p-3" "rounded-md" "transition-all" "duration-200"]
-                                                           node-className (common/cn base-classes selection-classes common-classes)
-                                                           has-human-request (:human-request data)
-                                                           has-exceptions (seq (:exceptions data))]
-                                                       ($ :div {:className "relative"}
-                                                          ($ :div {:className node-className
-                                                                   :style {:width "170px" :height "40px" :opacity (if is-affected "0.6" "1.0")}}
-                                                             ($ :div {:className "truncate" :title label}
-                                                                label))
-                                                          ;; Consolidated status indicator bar in top-right corner
-                                                          ($ node-status-bar {:in-progress? in-progress?
-                                                                              :is-stuck? is-stuck?
-                                                                              :has-changes has-changes
-                                                                              :has-human-request has-human-request
-                                                                              :has-exceptions has-exceptions
-                                                                              :has-result (:result data)})
-                                                          ($ Handle {:type "target" :position "top"})
-                                                          ($ Handle {:type "source" :position "bottom"})))))
-
-                                                  "phantom"
-                                                  (uix.core/as-react
-                                                   (fn [{:keys [data]}]
-                                                     (let [data (js->clj data :keywordize-keys true)
-                                                           missing-node-id (:missing-node-id data)]
-                                                       ($ :div {:className "relative cursor-pointer"
-                                                                :onClick (fn [e]
-                                                                           (.stopPropagation e)
-                                                                           (println "phantom data" data)
-                                                                           (on-paginate-node missing-node-id))}
-                                                          ($ :div {:className "bg-gray-100 text-gray-600 p-3 rounded-md shadow-lg border-2 border-dashed border-gray-400 hover:bg-gray-200 transition-colors"
-                                                                   :style {:width "170px" :height "40px"}}
-                                                             ($ :div {:className "truncate" :title (:label data)}
-                                                                (:label data)))
-                                                          ($ Handle {:type "target" :position "top"})))))})
-                             :defaultEdgeOptions {:style {:strokeWidth 2 :stroke "#a5b4fc"}}
-                             :onNodeClick (fn [_ node] (handle-select-node-click node))}
-                  ($ MiniMap {:position "bottom-right" :pannable true :zoomable true})
-                  ($ Background {:variant "dots" :gap 12 :size 1 :color "#e0e0e0"})
-                  ($ Controls {:className "fill-gray-500 stroke-gray-500"}))))
-
-            ;; Show selected node details or forking input component
-            (when selected-node
+              ($ gantt/gantt-trace-view-connected {:invoke-id invoke-id
+                                                   :on-select-node on-select-node})
+              ($ react-flow/react-flow-view {:invoke-id invoke-id
+                                             :on-select-node on-select-node
+                                             :on-paginate-node on-paginate-node}))
+            (when selected-node-data
               (if forking-mode?
-                ($ forking-input-component {:selected-node selected-node
+                ($ forking-input-component {:selected-node-data selected-node-data
                                             :changed-nodes changed-nodes
                                             :on-change-node-input on-change-node-input
                                             :affected-nodes affected-nodes})
-                ($ selected-node-component {:selected-node selected-node
+                ($ selected-node-component {:selected-node-data selected-node-data
                                             :graph-data graph-data
                                             :on-paginate-node on-paginate-node
                                             :on-select-node on-select-node
-                                            :flow-nodes flow-nodes
                                             :module-id module-id
                                             :agent-name agent-name
                                             :invoke-id invoke-id}))))
-
-         ;; Always-visible right panel with tabs
          ($ right-panel {:graph-data graph-data
                          :summary-data summary-data
                          :changed-nodes changed-nodes
                          :on-remove-node-change on-remove-node-change
                          :affected-nodes affected-nodes
-                         :flow-nodes flow-nodes
                          :on-select-node on-select-node
                          :on-execute-fork on-execute-fork
                          :on-clear-fork on-clear-fork
@@ -1425,4 +1164,4 @@
                          :fork-of fork-of
                          :invoke-id invoke-id
                          :sidebar-width sidebar-width
-                         :on-sidebar-width-change set-sidebar-width})))))
+                         :on-sidebar-width-change set-sidebar-width!})))))

--- a/src/cljs/com/rpl/agent_o_rama/ui/invocations/react_flow_view.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/invocations/react_flow_view.cljs
@@ -1,0 +1,96 @@
+(ns com.rpl.agent-o-rama.ui.invocations.react-flow-view
+  (:require
+   [re-frame.core :as rf]
+   [uix.re-frame :refer [use-subscribe]]
+   [uix.core :as uix :refer [defui $]]
+   [com.rpl.agent-o-rama.ui.common :as common]
+   [com.rpl.agent-o-rama.ui.invocations.graph-node :as gn]
+   [com.rpl.agent-o-rama.ui.invocations.graph-status :refer [node-status-bar]]
+   ["@xyflow/react" :refer [ReactFlow Background Controls Handle MiniMap]]))
+
+(defui react-flow-view
+  [{:keys [invoke-id on-select-node on-paginate-node]}]
+  (let [flow-data (use-subscribe [:invocation/flow-nodes-and-edges invoke-id])
+        selected-node-id (use-subscribe [:invocation/selected-node-id invoke-id])
+        changed-nodes (use-subscribe [:invocation/changed-nodes invoke-id])
+        forking-mode? (use-subscribe [:invocation/forking-mode? invoke-id])
+        affected-nodes (use-subscribe [:invocation/affected-nodes invoke-id])
+        is-complete (use-subscribe [:invocation/is-complete invoke-id])
+        {:keys [nodes edges]} (or flow-data {:nodes [] :edges []})
+        flow-nodes (clj->js nodes)
+        flow-edges (clj->js (for [edge edges]
+                              (if (:implicit? edge)
+                                (assoc edge :style #js {:strokeDasharray "5 5"
+                                                        :stroke "#aaa"})
+                                edge)))
+        handle-select-node-click (fn [node]
+                                   (when on-select-node
+                                     (let [node-data (js->clj (aget node "data") :keywordize-keys true)]
+                                       (on-select-node (:node-id node-data)))))]
+    ($ :div {:style {:width "100%" :height "500px"}}
+       ($ ReactFlow {:nodes flow-nodes
+                     :edges flow-edges
+                     :proOptions (clj->js {:hideAttribution true})
+                     :nodeTypes (clj->js {"custom"
+                                          (uix.core/as-react
+                                           (fn [{:keys [data id]}]
+                                             (let [data (js->clj data :keywordize-keys true)
+                                                   label (:label data)
+                                                   node-id (:node-id data)
+                                                   selected (= (str selected-node-id) id)
+                                                   has-changes (contains? changed-nodes node-id)
+                                                   is-affected (and forking-mode? (contains? affected-nodes node-id))
+                                                   in-progress? (and (:start-time-millis data)
+                                                                     (not (:finish-time-millis data)))
+                                                   is-stuck? (and in-progress? is-complete)
+                                                   base-classes (cond
+                                                                  is-affected
+                                                                  ["bg-gray-300" "text-gray-500" "border-2" "border-gray-400"]
+                                                                  has-changes
+                                                                  ["bg-orange-500" "text-white" "border-2" "border-orange-600"]
+                                                                  (gn/agg-node? data)
+                                                                  ["bg-yellow-500" "text-white" "border-2" "border-yellow-600"]
+                                                                  (gn/starter-node? data)
+                                                                  ["bg-green-500" "text-white" "border-2" "border-green-600"]
+                                                                  :else
+                                                                  ["bg-white" "text-gray-800" "border-2" "border-gray-300"])
+                                                   selection-classes (if selected
+                                                                       ["ring-4" "ring-blue-400" "ring-opacity-75" "shadow-2xl" "transform" "scale-105"]
+                                                                       ["shadow-lg"])
+                                                   common-classes ["p-3" "rounded-md" "transition-all" "duration-200"]
+                                                   node-className (common/cn base-classes selection-classes common-classes)
+                                                   has-human-request (:human-request data)
+                                                   has-exceptions (seq (:exceptions data))]
+                                               ($ :div {:className "relative"}
+                                                  ($ :div {:className node-className
+                                                           :style {:width "170px" :height "40px" :opacity (if is-affected "0.6" "1.0")}}
+                                                     ($ :div {:className "truncate" :title label} label))
+                                                  ($ node-status-bar {:in-progress? in-progress?
+                                                                      :is-stuck? is-stuck?
+                                                                      :has-changes has-changes
+                                                                      :has-human-request has-human-request
+                                                                      :has-exceptions has-exceptions
+                                                                      :has-result (:result data)})
+                                                  ($ Handle {:type "target" :position "top"})
+                                                  ($ Handle {:type "source" :position "bottom"})))))
+
+                                          "phantom"
+                                          (uix.core/as-react
+                                           (fn [{:keys [data]}]
+                                             (let [data (js->clj data :keywordize-keys true)
+                                                   missing-node-id (:missing-node-id data)]
+                                               ($ :div {:className "relative cursor-pointer"
+                                                        :onClick (fn [e]
+                                                                   (.stopPropagation e)
+                                                                   (when on-paginate-node
+                                                                     (on-paginate-node missing-node-id)))}
+                                                  ($ :div {:className "bg-gray-100 text-gray-600 p-3 rounded-md shadow-lg border-2 border-dashed border-gray-400 hover:bg-gray-200 transition-colors"
+                                                           :style {:width "170px" :height "40px"}}
+                                                     ($ :div {:className "truncate" :title (:label data)}
+                                                        (:label data)))
+                                                  ($ Handle {:type "target" :position "top"})))))})
+                     :defaultEdgeOptions {:style {:strokeWidth 2 :stroke "#a5b4fc"}}
+                     :onNodeClick (fn [_ node] (handle-select-node-click node))}
+          ($ MiniMap {:position "bottom-right" :pannable true :zoomable true})
+          ($ Background {:variant "dots" :gap 12 :size 1 :color "#e0e0e0"})
+          ($ Controls {:className "fill-gray-500 stroke-gray-500"})))))

--- a/src/cljs/com/rpl/agent_o_rama/ui/invocations/subs.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/invocations/subs.cljs
@@ -1,0 +1,102 @@
+(ns com.rpl.agent-o-rama.ui.invocations.subs
+  (:require
+   [re-frame.core :as rf]
+   [com.rpl.agent-o-rama.ui.invocations.graph-layout :as graph-layout]))
+
+(defn invocation-ui-path
+  [invoke-id & path]
+  (into [:ui :invocations invoke-id] path))
+
+(defn- default-invocation-ui []
+  {:trace-view-mode "graph"
+   :sidebar-width 320
+   :selected-node-id nil
+   :forking-mode? false
+   :changed-nodes {}})
+
+(rf/reg-sub :invocation/ui
+  (fn [db [_ invoke-id]]
+    (merge (default-invocation-ui)
+           (get-in db [:ui :invocations invoke-id]))))
+
+(rf/reg-sub :invocation/selected-node-id
+  :<- [:invocation/ui]
+  (fn [ui [_ _invoke-id]]
+    (:selected-node-id ui)))
+
+(rf/reg-sub :invocation/forking-mode?
+  :<- [:invocation/ui]
+  (fn [ui [_ _invoke-id]]
+    (:forking-mode? ui)))
+
+(rf/reg-sub :invocation/changed-nodes
+  :<- [:invocation/ui]
+  (fn [ui [_ _invoke-id]]
+    (:changed-nodes ui)))
+
+(rf/reg-sub :invocation/trace-view-mode
+  :<- [:invocation/ui]
+  (fn [ui [_ _invoke-id]]
+    (:trace-view-mode ui)))
+
+(rf/reg-sub :invocation/sidebar-width
+  :<- [:invocation/ui]
+  (fn [ui [_ _invoke-id]]
+    (:sidebar-width ui)))
+
+(rf/reg-sub :invocation/state
+  (fn [db [_ invoke-id]]
+    (get-in db [:invocations-data invoke-id])))
+
+(rf/reg-sub :invocation/graph-data
+  :<- [:invocation/state]
+  (fn [state [_ _invoke-id]]
+    (get-in state [:graph :nodes])))
+
+(rf/reg-sub :invocation/real-edges
+  :<- [:invocation/state]
+  (fn [state [_ _invoke-id]]
+    (or (get-in state [:graph :edges]) [])))
+
+(rf/reg-sub :invocation/implicit-edges
+  :<- [:invocation/state]
+  (fn [state [_ _invoke-id]]
+    (or (:implicit-edges state) [])))
+
+(rf/reg-sub :invocation/is-complete
+  :<- [:invocation/state]
+  (fn [state [_ _invoke-id]]
+    (boolean (:is-complete state))))
+
+(rf/reg-sub :invocation/root-invoke-id
+  :<- [:invocation/state]
+  (fn [state [_ _invoke-id]]
+    (:root-invoke-id state)))
+
+(rf/reg-sub :invocation/summary
+  :<- [:invocation/state]
+  (fn [state [_ _invoke-id]]
+    (:summary state)))
+
+(rf/reg-sub :invocation/flow-nodes-and-edges
+  :<- [:invocation/graph-data]
+  :<- [:invocation/real-edges]
+  :<- [:invocation/implicit-edges]
+  (fn [[graph-data real-edges implicit-edges] [_ _invoke-id]]
+    (when (seq graph-data)
+      (graph-layout/process-graph-data graph-data real-edges implicit-edges))))
+
+(rf/reg-sub :invocation/affected-nodes
+  :<- [:invocation/graph-data]
+  :<- [:invocation/changed-nodes]
+  :<- [:invocation/forking-mode?]
+  (fn [[graph-data changed-nodes forking-mode?] [_ _invoke-id]]
+    (when forking-mode?
+      (graph-layout/find-downstream-nodes graph-data (set (keys changed-nodes))))))
+
+(rf/reg-sub :invocation/selected-node-data
+  :<- [:invocation/graph-data]
+  :<- [:invocation/selected-node-id]
+  (fn [[graph-data selected-node-id] [_ _invoke-id]]
+    (when-let [node-data (and graph-data selected-node-id (get graph-data selected-node-id))]
+      (assoc node-data :node-id selected-node-id))))

--- a/src/cljs/com/rpl/agent_o_rama/ui/re_frame.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/re_frame.cljs
@@ -41,9 +41,7 @@
    :route nil
    :forms {}
    :invocations-filters {}
-   :ui {:selected-node-id nil
-        :forking-mode? false
-        :changed-nodes {}
+   :ui {:invocations {}
         :active-tab :info
         :current-route "/"
         :modal {:active nil
@@ -92,8 +90,8 @@
             path-value-pairs)))
 
 (rf/reg-event-db :ui/toggle-forking-mode
-  (fn [db _]
-    (update-in db [:ui :forking-mode?] not)))
+  (fn [db [_ invoke-id]]
+    (update-in db [:ui :invocations invoke-id :forking-mode?] not)))
 
 (rf/reg-event-db :invocation/update-node
   (fn [db [_ invoke-id node-id node-data]]

--- a/test/clj/com/rpl/agent_o_rama/impl/ui/rpc/invocations_test.clj
+++ b/test/clj/com/rpl/agent_o_rama/impl/ui/rpc/invocations_test.clj
@@ -1,0 +1,38 @@
+(ns com.rpl.agent-o-rama.impl.ui.rpc.invocations-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [com.rpl.agent-o-rama.impl.ui.rpc.invocations :as inv]))
+
+(def root-id #uuid "00000000-0000-0000-0000-000000000001")
+(def child-id #uuid "00000000-0000-0000-0000-000000000002")
+
+(deftest trace-graph-complete-test
+  (testing "all reachable drawable nodes must have finish time"
+    (let [nodes {root-id {:node "root"
+                          :start-time-millis 0
+                          :finish-time-millis 100
+                          :emits [{:invoke-id child-id}]}
+                 child-id {:node "child"
+                           :start-time-millis 10
+                           :finish-time-millis 50
+                           :emits []}}]
+      (is (inv/trace-graph-complete? nodes root-id))))
+
+  (testing "in-progress child makes graph incomplete"
+    (let [nodes {root-id {:node "root"
+                          :start-time-millis 0
+                          :finish-time-millis 100
+                          :emits [{:invoke-id child-id}]}
+                 child-id {:node "child"
+                           :start-time-millis 10
+                           :emits []}}]
+      (is (not (inv/trace-graph-complete? nodes root-id)))))
+
+  (testing "incomplete nodes without :node are skipped"
+    (let [phantom-id #uuid "00000000-0000-0000-0000-000000000099"
+          nodes {root-id {:node "root"
+                          :start-time-millis 0
+                          :finish-time-millis 100
+                          :emits [{:invoke-id phantom-id}]}
+                 phantom-id {}}]
+      (is (inv/trace-graph-complete? nodes root-id)))))

--- a/test/cljs/com/rpl/agent_o_rama/ui/dom.cljs
+++ b/test/cljs/com/rpl/agent_o_rama/ui/dom.cljs
@@ -30,6 +30,13 @@
     (when-not (or (not (exists? js/cancelAnimationFrame))
                   (not js/cancelAnimationFrame))
       (set! js/cancelAnimationFrame
-            (fn [id] (js/clearTimeout id))))))
+            (fn [id] (js/clearTimeout id))))
+
+    ;; localStorage for re-frame UI preference fx in tests
+    (when-not (exists? js/localStorage)
+      (set! js/localStorage
+            #js {:getItem (fn [_key] nil)
+                 :setItem (fn [_key _val] nil)
+                 :removeItem (fn [_key] nil)}))))
 
 (setup-dom!)

--- a/test/cljs/com/rpl/agent_o_rama/ui/invocations/gantt_trace_test.cljs
+++ b/test/cljs/com/rpl/agent_o_rama/ui/invocations/gantt_trace_test.cljs
@@ -1,0 +1,111 @@
+(ns com.rpl.agent-o-rama.ui.invocations.gantt-trace-test
+  (:require
+   [cljs.test :refer-macros [deftest testing is]]
+   [com.rpl.agent-o-rama.ui.invocations.gantt-trace :as gantt]))
+
+(def root-id #uuid "00000000-0000-0000-0000-000000000001")
+(def child-a #uuid "00000000-0000-0000-0000-000000000002")
+(def child-b #uuid "00000000-0000-0000-0000-000000000003")
+(def agg-id #uuid "00000000-0000-0000-0000-000000000004")
+(def starter-id #uuid "00000000-0000-0000-0000-000000000005")
+
+(defn- stress-like-graph []
+  {root-id {:node "stress-root"
+            :start-time-millis 1000
+            :finish-time-millis 5000}
+   starter-id {:node "stress-fanout"
+               :started-agg? true
+               :start-time-millis 1100
+               :finish-time-millis 2000}
+   child-a {:node "stress-worker"
+            :start-time-millis 1200
+            :finish-time-millis 1800}
+   child-b {:node "stress-worker"
+            :start-time-millis 1250
+            :finish-time-millis 1900}
+   agg-id {:node "stress-agg"
+           :agg-state {}
+           :start-time-millis 2000
+           :finish-time-millis 4500}})
+
+(defn- stress-like-edges []
+  {:real [{:source (str root-id) :target (str starter-id)}
+          {:source (str starter-id) :target (str child-a)}
+          {:source (str starter-id) :target (str child-b)}
+          {:source (str child-a) :target (str agg-id)}
+          {:source (str child-b) :target (str agg-id)}]
+   :implicit [{:source (str starter-id) :target (str agg-id) :implicit? true}]})
+
+(deftest format-duration-ms-test
+  (testing "duration formatting"
+    (is (= "—" (gantt/format-duration-ms nil)))
+    (is (= "42ms" (gantt/format-duration-ms 42)))
+    (is (= "1.50s" (gantt/format-duration-ms 1500)))
+    (is (= "2.00m" (gantt/format-duration-ms 120000)))))
+
+(deftest collect-visible-rows-test
+  (testing "DFS row order and labels"
+    (let [graph (stress-like-graph)
+          {:keys [real implicit]} (stress-like-edges)
+          children (gantt/gantt-children-map graph real implicit)
+          rows (gantt/collect-visible-rows graph children root-id #{})]
+      (is (= 5 (count rows)))
+      (is (= "stress-root" (:label (first rows))))
+      (is (= #{"stress-root" "stress-fanout" "stress-worker" "stress-agg"}
+             (set (map :label rows))))
+      (is (= 0 (:depth (first rows))))
+      (is (some #(> (:depth %) 0) rows))))
+
+  (testing "collapse hides descendant rows"
+    (let [graph (stress-like-graph)
+          {:keys [real implicit]} (stress-like-edges)
+          children (gantt/gantt-children-map graph real implicit)
+          root-str (str root-id)
+          rows-collapsed (gantt/collect-visible-rows graph children root-id #{root-str})]
+      (is (= 1 (count rows-collapsed)))
+      (is (= "stress-root" (:label (first rows-collapsed)))))))
+
+(deftest gantt-children-map-fan-in-test
+  (testing "agg appears under only one parent when multiple edges exist"
+    (let [graph (stress-like-graph)
+          {:keys [real implicit]} (stress-like-edges)
+          children (gantt/gantt-children-map graph real implicit)
+          agg-str (str agg-id)
+          parents-with-agg (->> children
+                                (filter (fn [[_ child-ids]]
+                                          (some #(= (str %) agg-str) child-ids)))
+                                (map first)
+                                vec)]
+      (is (= 1 (count parents-with-agg))
+          "agg should be listed once in the children map")
+      (is (contains? #{(str starter-id) (str child-a) (str child-b)}
+                     (first parents-with-agg))))))
+
+(deftest trace-time-bounds-test
+  (testing "bounds span finished nodes"
+    (let [graph (stress-like-graph)
+          {:keys [real implicit]} (stress-like-edges)
+          children (gantt/gantt-children-map graph real implicit)
+          rows (gantt/collect-visible-rows graph children root-id #{})
+          [t0 t1] (gantt/trace-time-bounds rows 99999)]
+      (is (= 1000 t0))
+      (is (= 5000 t1))))
+
+  (testing "in-progress row extends bounds to now-ms"
+    (let [in-progress-id #uuid "00000000-0000-0000-0000-000000000099"
+          graph {root-id {:node "root"
+                          :start-time-millis 1000
+                          :finish-time-millis 2000}
+                 in-progress-id {:node "worker"
+                                 :start-time-millis 1500}}
+          edges [{:source (str root-id) :target (str in-progress-id)}]
+          children (gantt/gantt-children-map graph edges [])
+          rows (gantt/collect-visible-rows graph children root-id #{})
+          now 5000
+          [t0 t1] (gantt/trace-time-bounds rows now)]
+      (is (= 1000 t0))
+      (is (= now t1)))))
+
+(deftest empty-graph-rows-test
+  (testing "no root yields empty rows"
+    (is (empty? (gantt/collect-visible-rows {} {} nil #{})))))

--- a/test/cljs/com/rpl/agent_o_rama/ui/invocations/invocation_flow_test.cljs
+++ b/test/cljs/com/rpl/agent_o_rama/ui/invocations/invocation_flow_test.cljs
@@ -1,0 +1,81 @@
+(ns com.rpl.agent-o-rama.ui.invocations.invocation-flow-test
+  "Tests for invocation graph subscriptions, polling, and re-frame data flow."
+  (:require
+   [cljs.test :refer-macros [deftest testing is]]
+   [com.rpl.agent-o-rama.ui.dom]
+   [com.rpl.agent-o-rama.ui.events :as events]
+   [com.rpl.agent-o-rama.ui.invocations.subs :as inv-subs]
+   [com.rpl.agent-o-rama.ui.re-frame :as aor-rf]
+   [re-frame.core :as rf]
+   [re-frame.db :as rdb]))
+
+(def invoke-id "test-invoke-1")
+(def root-id #uuid "00000000-0000-0000-0000-000000000010")
+(def worker-id #uuid "00000000-0000-0000-0000-000000000011")
+
+(defn- sample-nodes []
+  {root-id {:node "root"
+            :start-time-millis 100
+            :finish-time-millis 500}
+   worker-id {:node "worker"
+              :start-time-millis 200
+              :finish-time-millis 400}})
+
+(defn- db-with-graph [nodes & {:keys [is-complete]}]
+  (assoc-in aor-rf/default-app-db
+            [:invocations-data invoke-id]
+            {:status :success
+             :graph {:nodes nodes
+                     :edges [{:source (str root-id) :target (str worker-id)}]}
+             :implicit-edges []
+             :root-invoke-id root-id
+             :is-complete (boolean is-complete)}))
+
+(deftest invocation-graph-data-sub-test
+  (reset! rdb/app-db (db-with-graph (sample-nodes)))
+  (is (= (sample-nodes)
+         (get-in @rdb/app-db [:invocations-data invoke-id :graph :nodes]))))
+
+(deftest invocation-selected-node-data-test
+  (let [nodes (sample-nodes)
+        db (-> (db-with-graph nodes)
+               (assoc-in [:ui :invocations invoke-id :selected-node-id] worker-id))]
+    (reset! rdb/app-db db)
+    (let [graph-data (get-in db [:invocations-data invoke-id :graph :nodes])
+          selected-id (get-in db [:ui :invocations invoke-id :selected-node-id])
+          node-data (get graph-data selected-id)]
+      (is (= worker-id selected-id))
+      (is (= "worker" (:node (assoc node-data :node-id selected-id))))))
+
+(deftest should-schedule-poll-test
+  (testing "poll while agent not complete"
+    (let [db (db-with-graph (sample-nodes) :is-complete false)]
+      (is (events/should-schedule-poll? db invoke-id false))))
+
+  (testing "drain poll when agent complete but worker in progress"
+    (let [nodes (assoc (sample-nodes) worker-id
+                       {:node "worker" :start-time-millis 200})
+          db (db-with-graph nodes :is-complete true)]
+      (is (events/should-schedule-poll? db invoke-id true))))
+
+  (testing "stop poll when agent and all nodes finished"
+    (let [db (db-with-graph (sample-nodes) :is-complete true)]
+      (is (not (events/should-schedule-poll? db invoke-id true))))))
+
+(deftest invocation-cleanup-test
+  (reset! rdb/app-db
+          (-> (db-with-graph (sample-nodes))
+              (assoc-in [:ui :invocations invoke-id :selected-node-id] worker-id)
+              (assoc :current-invocation {:invoke-id invoke-id})))
+  (rf/dispatch-sync [:invocation/cleanup {:invoke-id invoke-id}])
+  (is (nil? (get-in @rdb/app-db [:invocations-data invoke-id])))
+  (is (nil? (get-in @rdb/app-db [:ui :invocations invoke-id]))))
+
+(deftest trace-view-mode-event-test
+  (reset! rdb/app-db aor-rf/default-app-db)
+  (rf/dispatch-sync [:invocation/set-trace-view-mode invoke-id "gantt"])
+  (is (= "gantt" (get-in @rdb/app-db [:ui :invocations invoke-id :trace-view-mode]))))
+
+(deftest invocation-ui-path-test
+  (is (= [:ui :invocations invoke-id :selected-node-id]
+         (inv-subs/invocation-ui-path invoke-id :selected-node-id)))))

--- a/test/cljs/com/rpl/agent_o_rama/ui/state_test.cljs
+++ b/test/cljs/com/rpl/agent_o_rama/ui/state_test.cljs
@@ -55,7 +55,7 @@
 (deftest test-toggle-forking-mode
   (reset! rdb/app-db aor-rf/default-app-db)
   (let [invoke-id "test-invoke"]
-    (is (false? (get-in @rdb/app-db [:ui :invocations invoke-id :forking-mode?])))
+    (is (not (get-in @rdb/app-db [:ui :invocations invoke-id :forking-mode?])))
     (rf/dispatch-sync [:ui/toggle-forking-mode invoke-id])
     (is (true? (get-in @rdb/app-db [:ui :invocations invoke-id :forking-mode?])))
     (rf/dispatch-sync [:ui/toggle-forking-mode invoke-id])

--- a/test/cljs/com/rpl/agent_o_rama/ui/state_test.cljs
+++ b/test/cljs/com/rpl/agent_o_rama/ui/state_test.cljs
@@ -3,6 +3,7 @@
    [cljs.test :refer-macros [deftest is]]
    [com.rpl.agent-o-rama.ui.re-frame :as aor-rf]
    [com.rpl.agent-o-rama.ui.events]
+   [com.rpl.agent-o-rama.ui.invocations.subs]
    [re-frame.core :as rf]
    [re-frame.db :as rdb]
    [com.rpl.agent-o-rama.ui.dom])) ; Load DOM setup before tests
@@ -25,8 +26,8 @@
       (is (boolean? (:loading? inv))))
     (is (contains? db :ui))
     (let [ui (:ui db)]
-      (is (contains? ui :forking-mode?))
-      (is (boolean? (:forking-mode? ui))))))
+      (is (contains? ui :invocations))
+      (is (map? (:invocations ui))))))
 
 (deftest test-event-system
   (let [test-event-id ::test-event
@@ -43,17 +44,19 @@
 
 (deftest test-db-set-value-event
   (reset! rdb/app-db aor-rf/default-app-db)
-  (let [test-uuid (random-uuid)]
-    (rf/dispatch-sync [:db/set-value [:ui :selected-node-id] test-uuid])
-    (is (= test-uuid (get-in @rdb/app-db [:ui :selected-node-id]))))
+  (let [test-uuid (random-uuid)
+        invoke-id "test-invoke"]
+    (rf/dispatch-sync [:invocation/select-node invoke-id test-uuid])
+    (is (= test-uuid (get-in @rdb/app-db [:ui :invocations invoke-id :selected-node-id]))))
   (reset! rdb/app-db aor-rf/default-app-db)
   (rf/dispatch-sync [:db/set-value [:current-invocation :invoke-id] "invoke-456"])
   (is (= "invoke-456" (get-in @rdb/app-db [:current-invocation :invoke-id]))))
 
 (deftest test-toggle-forking-mode
   (reset! rdb/app-db aor-rf/default-app-db)
-  (is (false? (get-in @rdb/app-db [:ui :forking-mode?])))
-  (rf/dispatch-sync [:ui/toggle-forking-mode])
-  (is (true? (get-in @rdb/app-db [:ui :forking-mode?])))
-  (rf/dispatch-sync [:ui/toggle-forking-mode])
-  (is (false? (get-in @rdb/app-db [:ui :forking-mode?]))))
+  (let [invoke-id "test-invoke"]
+    (is (false? (get-in @rdb/app-db [:ui :invocations invoke-id :forking-mode?])))
+    (rf/dispatch-sync [:ui/toggle-forking-mode invoke-id])
+    (is (true? (get-in @rdb/app-db [:ui :invocations invoke-id :forking-mode?])))
+    (rf/dispatch-sync [:ui/toggle-forking-mode invoke-id])
+    (is (false? (get-in @rdb/app-db [:ui :invocations invoke-id :forking-mode?])))))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Applies the Opus analysis refactor to fix stale Gantt updates and simplify the invocation trace architecture.

## Changes

### Data flow (re-frame as single source of truth)
- New `subs.cljs` with `:invocation/graph-data`, edges, flow layout, selected node, and per-invocation UI subscriptions
- `detail.cljs` stops rebuilding `graph-data` via `(into {} (for ...))` every render
- `graph-view` orchestrates only; leaf views subscribe directly

### React Flow
- New `react_flow_view.cljs` — controlled nodes/edges from `:invocation/flow-nodes-and-edges` (no `useNodesState` / sync `useEffect` chain)
- `graph_layout.cljs` — shared Dagre layout + downstream-node helpers
- `graph_status.cljs` — extracted `node-status-bar`

### Gantt
- `gantt-trace-view-connected` subscribes to the same re-frame paths as the graph view
- **Bug fix:** `collect-visible-rows` now passes `(inc depth)` when recursing into children

### UI state
- Per-invocation paths: `[:ui :invocations invoke-id ...]` for selected node, fork state, trace view mode, sidebar width
- localStorage persisted via `:invocation/persist-ui-preference` fx

### Polling lifecycle
- Cancellable `:invocation/poll-schedule` / `:invocation/poll-cancel` reg-fx
- Drain polls while reachable nodes lack `:finish-time-millis`
- Cleanup cancels polls and clears invocation data

### Backend
- `get-graph-page!!` reports `is-complete` only when agent summary is done **and** all reachable trace nodes have `:finish-time-millis`

### Tests
- **CLJS** (`node target/test/test.js`): 41 tests, 302 assertions — includes new `gantt-trace-test` and `invocation-flow-test`
- **CLJ**: `invocations-test` for `trace-graph-complete?`
- E2E: existing Playwright `trace-rendering.spec.js` covers Gantt stress agent UI

## Testing

```bash
lein with-profile +ui run -m shadow.cljs.devtools.cli compile :test && node target/test/test.js
lein test com.rpl.agent-o-rama.impl.ui.rpc.invocations-test
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-552f772a-0d59-4dbe-acd0-277ad60694a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-552f772a-0d59-4dbe-acd0-277ad60694a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

