### PR TITLE
Add getUnderlyingPState to PStateStore

### DIFF
--- a/src/clj/com/rpl/agent_o_rama/impl/store_impl.clj
+++ b/src/clj/com/rpl/agent_o_rama/impl/store_impl.clj
@@ -269,6 +269,9 @@
 (defn PStateStoreImpl
   [store-params]
   `(PStateStore
+    (~'getUnderlyingPState
+     [this#]
+     (:pstate-client ~store-params))
     (~'select
      [this# jpath#]
      (pstate-select* this# (java-path->clojure-path jpath#)))

--- a/src/clj/com/rpl/agent_o_rama/store.clj
+++ b/src/clj/com/rpl/agent_o_rama/store.clj
@@ -23,7 +23,23 @@ Example:\n
   (:use [com.rpl.rama path])
   (:refer-clojure :exclude [get contains?])
   (:require
-   [com.rpl.agent-o-rama.impl.store-impl :as simpl]))
+   [com.rpl.agent-o-rama.impl.store-impl :as simpl])
+  (:import
+   [com.rpl.agentorama.store PStateStore]
+   [com.rpl.rama PState]))
+
+(defn get-underlying-pstate
+  "Returns the underlying Rama PState for a store.\n
+\n
+Enables standard Rama foreign operations (e.g. `foreign-select-one-async`) on agent stores.\n
+\n
+Args:\n
+  - store - Store instance obtained from [[com.rpl.agent-o-rama/get-store]]
+\n
+Returns:\n
+  - The underlying PState client"
+  ^PState [^PStateStore store]
+  (.getUnderlyingPState store))
 
 (defn get
   "Gets a value from a key-value store.\n

--- a/src/java/com/rpl/agentorama/store/PStateStore.java
+++ b/src/java/com/rpl/agentorama/store/PStateStore.java
@@ -2,6 +2,7 @@ package com.rpl.agentorama.store;
 
 import java.util.List;
 import com.rpl.rama.Path;
+import com.rpl.rama.PState;
 
 /**
  * Direct access to Rama's built-in PState storage.
@@ -12,6 +13,16 @@ import com.rpl.rama.Path;
  * @see <a href="https://redplanetlabs.com/docs/~/pstates.html">PStates Documentation</a>
  */
 public interface PStateStore extends Store {
+  /**
+   * Returns the underlying Rama PState for this store.
+   *
+   * <p>This enables use of standard Rama foreign operations (e.g. {@code foreign-select-one-async})
+   * on agent stores, so the same code can work with both raw PState references and AoR stores.
+   *
+   * @return the underlying PState client
+   */
+  PState getUnderlyingPState();
+
   /**
    * Selects data using a path expression.
    *

--- a/test/clj/com/rpl/agent_o_rama_test.clj
+++ b/test/clj/com/rpl/agent_o_rama_test.clj
@@ -1075,7 +1075,8 @@
                             :c (store/get kv :c)
                             :d (store/get kv :d)
                             :e (store/pstate-select [:b ALL] kv)
-                            :f (.get (foreign-select-one-async :a (store/get-underlying-pstate kv)))
+                            :f (store/pstate-select-one :a kv)
+                            :async-f (.get (foreign-select-one-async :a (store/get-underlying-pstate kv)))
                             :g [(store/pstate-select :zz kv :e)
                                 (store/pstate-select :zz kv)]
                             :h [(store/pstate-select-one :zz kv :e)
@@ -1119,7 +1120,8 @@
                        :mc    (store/get-document-field doc :m :c)
                        :ma?   (store/contains-document-field? doc :m :a)
                        :mc?   (store/contains-document-field? doc :m :c)
-                       :psa   (.get (foreign-select-one-async [:s :a] (store/get-underlying-pstate doc)))
+                       :psa   (store/pstate-select-one [:s :a] doc)
+                       :async-psa (.get (foreign-select-one-async [:s :a] (store/get-underlying-pstate doc)))
                        :psb   (store/pstate-select [:s :b ALL] doc)
                        :pzz   [(store/pstate-select :zz doc :e)
                                (store/pstate-select :zz doc)]
@@ -1156,11 +1158,13 @@
                  res
                  :pstate {:ks   (store/pstate-select [:a MAP-KEYS] p)
                           :kv   (store/pstate-select [:a MAP-VALS] p)
-                          :k0   (.get (foreign-select-one-async [:a 0] (store/get-underlying-pstate p) {:pkey :a}))
+                          :k0   (store/pstate-select-one [:a 0] p)
+                          :async-k0 (.get (foreign-select-one-async [:a 0] (store/get-underlying-pstate p) {:pkey :a}))
                           :zz0  [(store/pstate-select [:zz 0] p :e)
                                  (store/pstate-select [:zz 0] p)]
-                          :zz02 [(.get (foreign-select-one-async [:zz 0] (store/get-underlying-pstate p) {:pkey :e}))
+                          :zz02 [(store/pstate-select-one [:zz 0] p :e)
                                  (store/pstate-select-one [:zz 0] p)]
+                          :async-zz0 (.get (foreign-select-one-async [:zz 0] (store/get-underlying-pstate p) {:pkey :e}))
                          }))
              )))
           (aor/node "end"
@@ -1199,6 +1203,7 @@
                       :d 3
                       :e [3]
                       :f 3
+                      :async-f 3
                       :g [[3] [nil]]
                       :h [3 nil]
                       :i true
@@ -1214,6 +1219,7 @@
                       :ma?   true
                       :mc?   false
                       :psa   6
+                      :async-psa 6
                       :psb   [10 3]
                       :pzz   [[{:a 3 :b [4]}]
                               [nil]]
@@ -1224,8 +1230,10 @@
              :pstate {:ks   [0 1]
                       :kv   [53 3]
                       :k0   53
+                      :async-k0 53
                       :zz0  [[3] [nil]]
-                      :zz02 [3 nil]}}
+                      :zz02 [3 nil]
+                      :async-zz0 3}}
             (:val (invoke-agent-and-return! depot root-pstate [3]))))
      (is (= {:kv     {:a 1
                       :b [3 1]
@@ -1233,6 +1241,7 @@
                       :d 4
                       :e [3 1]
                       :f 1
+                      :async-f 1
                       :g [[1] [nil]]
                       :h [1 nil]
                       :i true
@@ -1248,6 +1257,7 @@
                       :ma?   true
                       :mc?   false
                       :psa   14
+                      :async-psa 14
                       :psb   [10 3 1]
                       :pzz   [[{:a 1 :b [2]}]
                               [nil]]
@@ -1258,8 +1268,10 @@
              :pstate {:ks   [0 1 2]
                       :kv   [54 3 1]
                       :k0   54
+                      :async-k0 54
                       :zz0  [[1] [nil]]
-                      :zz02 [1 nil]}}
+                      :zz02 [1 nil]
+                      :async-zz0 1}}
             (:val (invoke-agent-and-return! depot root-pstate [1]))))
      (is (= 1 (foreign-select-one :a kv)))
      (is (= [3 1] (foreign-select-one :b kv)))

--- a/test/clj/com/rpl/agent_o_rama_test.clj
+++ b/test/clj/com/rpl/agent_o_rama_test.clj
@@ -1075,7 +1075,7 @@
                             :c (store/get kv :c)
                             :d (store/get kv :d)
                             :e (store/pstate-select [:b ALL] kv)
-                            :f (store/pstate-select-one :a kv)
+                            :f (.get (foreign-select-one-async :a (store/get-underlying-pstate kv)))
                             :g [(store/pstate-select :zz kv :e)
                                 (store/pstate-select :zz kv)]
                             :h [(store/pstate-select-one :zz kv :e)
@@ -1119,7 +1119,7 @@
                        :mc    (store/get-document-field doc :m :c)
                        :ma?   (store/contains-document-field? doc :m :a)
                        :mc?   (store/contains-document-field? doc :m :c)
-                       :psa   (store/pstate-select-one [:s :a] doc)
+                       :psa   (.get (foreign-select-one-async [:s :a] (store/get-underlying-pstate doc)))
                        :psb   (store/pstate-select [:s :b ALL] doc)
                        :pzz   [(store/pstate-select :zz doc :e)
                                (store/pstate-select :zz doc)]
@@ -1156,10 +1156,10 @@
                  res
                  :pstate {:ks   (store/pstate-select [:a MAP-KEYS] p)
                           :kv   (store/pstate-select [:a MAP-VALS] p)
-                          :k0   (store/pstate-select-one [:a 0] p)
+                          :k0   (.get (foreign-select-one-async [:a 0] (store/get-underlying-pstate p) {:pkey :a}))
                           :zz0  [(store/pstate-select [:zz 0] p :e)
                                  (store/pstate-select [:zz 0] p)]
-                          :zz02 [(store/pstate-select-one [:zz 0] p :e)
+                          :zz02 [(.get (foreign-select-one-async [:zz 0] (store/get-underlying-pstate p) {:pkey :e}))
                                  (store/pstate-select-one [:zz 0] p)]
                          }))
              )))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #303

Adds `PStateStore.getUnderlyingPState()` so agent stores expose the underlying Rama `PState` client. This lets callers use standard Rama foreign operations (e.g. `foreign-select-one-async`) on AoR stores, avoiding duplicate verb implementations for in-agent vs out-of-agent use.

## Changes

- **Java API**: `PStateStore.getUnderlyingPState()` returns the `PState` client
- **Clojure API**: `store/get-underlying-pstate` wrapper
- **Implementation**: returns `(:pstate-client store-params)` from existing store impl
- **Test**: `stores-test` keeps all existing `store/pstate-select-one` coverage and adds separate `:async-*` fields that exercise `get-underlying-pstate` with `foreign-select-one-async`

## Example

```clojure
(foreign-select-one-async (keypath source) (store/get-underlying-pstate $$sources))
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a893609b-ae29-44ec-9a7a-c23bfe79ce9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a893609b-ae29-44ec-9a7a-c23bfe79ce9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

