### PR TITLE
Fix editing dataset examples when reference output is nil (#289)

### DIFF
--- a/src/clj/com/rpl/agent_o_rama/impl/datasets.clj
+++ b/src/clj/com/rpl/agent_o_rama/impl/datasets.clj
@@ -443,7 +443,8 @@
 
       (case> (= *key :reference-output))
        (get *props :output-json-schema :> *output-json-schema)
-       (validate-with-schema> *output-json-schema *value)
+       (<<if (some? *value)
+         (validate-with-schema> *output-json-schema *value))
 
       (default>))
      (update-dataset-example!

--- a/src/clj/com/rpl/agent_o_rama/impl/types.clj
+++ b/src/clj/com/rpl/agent_o_rama/impl/types.clj
@@ -453,7 +453,7 @@
    snapshot-name :- (s/maybe String)
    example-id :- UUID
    key :- clojure.lang.Keyword
-   value :- Object])
+   value :- s/Any])
 
 (defaorrecord RemoveDatasetExample
   [dataset-id :- UUID

--- a/test/clj/com/rpl/datasets_test.clj
+++ b/test/clj/com/rpl/datasets_test.clj
@@ -1106,6 +1106,12 @@
                                     :info)
                                 "$: integer found, string expected"))))
 
+       ;; nil reference-output updates must not fail schema construction (#289)
+       (aor/set-dataset-example-reference-output! manager ds-id3 id1 nil)
+       (aor/set-dataset-example-reference-output! manager ds-id3 id1 "ww")
+       (aor/set-dataset-example-input! manager ds-id3 id2 {"p1" [] "p2" "abc"})
+       (aor/set-dataset-example-reference-output! manager ds-id3 id2 nil)
+
        (bind {:keys [examples pagination-params]}
          (get-examples-page ds-id3 nil 10 nil))
        (is (nil? pagination-params))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Editing a dataset example's **input** when **reference output** is `nil` fails with `"constructed record does not satisfy schema"`. The UI `edit-example!!` path always sends both `input` and `reference-output`; input-only edits still trigger a reference-output update with `nil`, which `UpdateDatasetExample` rejected because `value` was typed as `Object` (non-nil).

## Fix

- Change `UpdateDatasetExample.value` from `Object` to `s/Any` so explicit `nil` reference-output updates are valid (per [#289](https://github.com/redplanetlabs/agent-o-rama/issues/289)).
- Skip output JSON schema validation when updating reference-output to `nil`, consistent with `AddDatasetExample`.

## Testing

- Extended `dataset-operations-test` in `datasets_test.clj` to cover clearing reference output to `nil` and the edit path that re-sends `nil` reference-output alongside input updates.
- `lein test :only com.rpl.datasets-test` — all 21 tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abafce8f-3728-4fb1-a443-dc5e27cdbea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abafce8f-3728-4fb1-a443-dc5e27cdbea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

