### PR TITLE
Add getClusterRetriever to AgentNode

### DIFF
--- a/src/clj/com/rpl/agent_o_rama/impl/agent_node.clj
+++ b/src/clj/com/rpl/agent_o_rama/impl/agent_node.clj
@@ -556,6 +556,8 @@
                         (.getMirrorAgentClient declared-objects-tg module-name name)
                         module-name
                         name))
+     (getClusterRetriever [this]
+       (.getClusterRetriever declared-objects-tg))
      (getStore [this name]
        (mk-store (:store-info store-info)
                  (.getThisModuleName declared-objects-tg)

--- a/src/java/com/rpl/agentorama/AgentNode.java
+++ b/src/java/com/rpl/agentorama/AgentNode.java
@@ -49,6 +49,8 @@ public interface AgentNode extends AgentObjectFetcher, IFetchAgentClient {
 
   AgentClient getMirrorAgentClient(String moduleName, String agentName);
 
+  com.rpl.rama.cluster.ClusterManagerBase getClusterRetriever();
+
   /**
    * Gets a store by name for persistent data access.
    *

--- a/test/clj/com/rpl/rama_objects_test.clj
+++ b/test/clj/com/rpl/rama_objects_test.clj
@@ -132,6 +132,9 @@
                       q3        (aor/get-query-topology-client agent-node "q")
                       q1        (aor/get-mirror-query-topology-client agent-node module1-name "q")
                       q2        (aor/get-mirror-query-topology-client agent-node module2-name "q")
+                      retriever (.getClusterRetriever agent-node)
+                      manager   (aor/agent-manager retriever module2-name)
+                      foo-via-retriever (aor/agent-client manager "foo")
                       res       (volatile! [])]
                   (foreign-append! depot1 k)
                   (vswap! res conj (store/pstate-select-one (keypath k) p1))
@@ -142,6 +145,11 @@
                   (vswap! res conj (foreign-invoke-query q1 "."))
                   (vswap! res conj (foreign-invoke-query q2 "."))
                   (vswap! res conj (foreign-invoke-query q3 "."))
+                  (vswap! res conj
+                          (foreign-invoke-query
+                           (foreign-query retriever module1-name "q")
+                           "r"))
+                  (vswap! res conj (aor/agent-invoke foo-via-retriever :via-retriever))
                   (aor/agent-invoke foo-m2 k)
                   (vswap! res conj (h/contains-string? (str (class m2-kv)) "mk_kv_store"))
                   (vswap! res conj (h/contains-string? (str (class m2-doc)) "mk_doc_store"))
@@ -180,7 +188,7 @@
      (bind res (aor/agent-result foo inv))
 
      (is (= res
-            [1 :abc :def ".!" ".!!" ".!!!" true true true 1 {:a 1} 1
+            [1 :abc :def ".!" ".!!" ".!!!" "r!" :done true true true 1 {:a 1} 1
              {:name "*depot" :module-name module1-name :num-partitions 1}
              {:start-offset 0 :end-offset 4} [:a :x :y]]
          ))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #302

Adds `getClusterRetriever()` to the `AgentNode` interface, delegating to the same `ClusterManagerBase` used in foreign topology context. This lets node functions construct `AgentManager` and other foreign Rama clients (e.g. `foreign-query`, `foreign-pstate`) without going through mirror helpers.

**Changes**
- `AgentNode.getClusterRetriever()` returns `com.rpl.rama.cluster.ClusterManagerBase`
- Implementation delegates to `AgentDeclaredObjectsTaskGlobal.getClusterRetriever()`
- Extended `rama-objects-test` to verify retriever-based query invocation and `AgentManager` client creation

**Test**
- `lein with-profile dev,provided test :only com.rpl.rama-objects-test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1df94ae1-35b1-4dc3-8cf3-807f0f55735b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1df94ae1-35b1-4dc3-8cf3-807f0f55735b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

