### PR TITLE
Fix all UIx linter warnings in ClojureScript frontend

### DIFF
--- a/src/cljs/com/rpl/agent_o_rama/ui/analytics.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/analytics.cljs
@@ -450,7 +450,7 @@
        (when (and value (not= search-term value))
          (set-search-term! value))
        js/undefined)
-     [value])
+     [search-term value])
 
     ($ :div.relative.w-full
        ($ :div.relative
@@ -762,6 +762,32 @@
              :variant actual-variant
              :variant-opts actual-variant-opts})))))
 
+(defui static-chart-card
+  "Renders a static analytics chart - handles its own data fetching to avoid hooks-in-loop issues."
+  [{:keys [config module-id agent-name granularity-config time-window metadata-key refresh-counter]}]
+  (let [{:keys [metric-id metrics-set]} config
+        {:keys [data loading? error]}
+        (queries/use-rpc-query
+         {:rfq-key ::rpc-analytics/fetch-telemetry!!
+          :params {:module-id module-id
+                   :agent-name agent-name
+                   :granularity (:seconds granularity-config)
+                   :metric-id metric-id
+                   :start-time-millis (:start-time-millis time-window)
+                   :end-time-millis (:end-time-millis time-window)
+                   :metrics-set metrics-set
+                   :metadata-key metadata-key
+                   :refresh-counter refresh-counter}
+          :enabled? (boolean (and module-id agent-name))})]
+    ($ chart-card
+       {:config config
+        :data data
+        :loading? loading?
+        :error error
+        :granularity-config granularity-config
+        :time-window time-window
+        :metadata-key metadata-key})))
+
 (defui analytics-page []
   (let [{:keys [module-id agent-name]} (use-subscribe [::aor-rf/get-in [:route :path-params]])
         ;; Get coerced parameters from Reitit - these are already typed correctly
@@ -776,11 +802,15 @@
         ;; Setters that update URL - accept optional overrides for when multiple values change at once
         set-granularity (uix/use-callback
                          (fn
-                           ([new-granularity] (set-granularity new-granularity nil nil))
+                           ([new-granularity]
+                            (let [final-granularity (if (fn? new-granularity)
+                                                        (new-granularity granularity)
+                                                        new-granularity)]
+                              (update-analytics-url module-id agent-name final-granularity time-offset metadata-key)))
                            ([new-granularity override-time-offset override-metadata-key]
                             (let [final-granularity (if (fn? new-granularity)
-                                                      (new-granularity granularity)
-                                                      new-granularity)
+                                                        (new-granularity granularity)
+                                                        new-granularity)
                                   final-time-offset (if (some? override-time-offset)
                                                       override-time-offset
                                                       time-offset)
@@ -811,7 +841,7 @@
         time-window (uix/use-memo
                      (fn []
                        (calculate-time-window (:seconds granularity-config) time-offset))
-                     [granularity time-offset])
+                     [granularity-config granularity time-offset])
 
         is-live? (:is-live? time-window)
 
@@ -851,34 +881,7 @@
                                       (filter #(and (vector? %) (= :human (first %))))
                                       (keep parse-human-metric-id)
                                       (mapv create-human-chart-config))))
-                             [all-metrics])
-
-        ;; Group ONLY static charts by metric-id (stable hook count)
-        static-metric-groups (uix/use-memo
-                              (fn [] (group-charts-by-metric chart-configs))
-                              [])
-
-        ;; Create queries for static metrics (HTTP RPC; refresh-counter bumps live window)
-        static-metric-queries
-        (into {}
-              (map (fn [[metric-id {:keys [metrics-set]}]]
-                     (let [{:keys [data loading? error]}
-                           (queries/use-rpc-query
-                            {:rfq-key ::rpc-analytics/fetch-telemetry!!
-                             :params {:module-id module-id
-                                      :agent-name decoded-agent-name
-                                      :granularity (:seconds granularity-config)
-                                      :metric-id metric-id
-                                      :start-time-millis (:start-time-millis time-window)
-                                      :end-time-millis (:end-time-millis time-window)
-                                      :metrics-set metrics-set
-                                      :metadata-key metadata-key
-                                      :refresh-counter refresh-counter}
-                             :enabled? (boolean (and module-id decoded-agent-name))})]
-                       [metric-id {:data data :loading? loading? :error error}]))
-                   static-metric-groups))
-
-        metric-queries static-metric-queries]
+                             [all-metrics])]
 
     ($ :div.p-6
        ;; Page header
@@ -901,17 +904,15 @@
        ;; Static metrics section
        ($ :div.grid.grid-cols-1.lg:grid-cols-2.gap-6
           (map (fn [config]
-                 (let [metric-id (:metric-id config)
-                       query-result (get metric-queries metric-id)]
-                   ($ chart-card
-                      {:key (:id config)
-                       :config config
-                       :data (:data query-result)
-                       :loading? (:loading? query-result)
-                       :error (:error query-result)
-                       :granularity-config granularity-config
-                       :time-window time-window
-                       :metadata-key metadata-key})))
+                 ($ static-chart-card
+                    {:key (:id config)
+                     :config config
+                     :module-id module-id
+                     :agent-name decoded-agent-name
+                     :granularity-config granularity-config
+                     :time-window time-window
+                     :metadata-key metadata-key
+                     :refresh-counter refresh-counter}))
                chart-configs))
 
        ;; Eval metrics section (if any exist)

--- a/src/cljs/com/rpl/agent_o_rama/ui/chart.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/chart.cljs
@@ -559,7 +559,7 @@
                (js/requestAnimationFrame handle-resize)
                (.addEventListener js/window "resize" handle-resize)
                (fn [] (.removeEventListener js/window "resize" handle-resize))))
-           [height chart-data])]
+           [height chart-data chart-ref])]
 
     ($ :div.w-full
        {:ref container-ref}

--- a/src/cljs/com/rpl/agent_o_rama/ui/datasets_forms.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/datasets_forms.cljs
@@ -339,6 +339,40 @@
 ;; BULK OPERATION MODALS
 ;; =============================================================================
 
+(defui AddTagForm [{:keys [form-id]}]
+  (let [{:keys [field-errors]} (forms/use-form form-id)
+        tag-name-field (forms/use-form-field form-id :tag-name)]
+
+    ($ forms/form
+       ($ forms/form-field {:label "Tag to add"
+                            :value (:value tag-name-field)
+                            :on-change (:on-change tag-name-field)
+                            :error (:error tag-name-field)
+                            :required? true}))))
+
+(defui RemoveTagForm [{:keys [form-id selected-examples]}]
+  (let [{:keys [field-errors]} (forms/use-form form-id)
+        tag-name-field (forms/use-form-field form-id :tag-name)
+
+        ;; Get all unique tags from selected examples
+        all-tags (->> selected-examples
+                      (mapcat :tags)
+                      (map name) ; Convert keywords to strings
+                      (distinct)
+                      (sort))]
+
+    ($ forms/form
+       ($ :div
+          ($ :label.block.text-sm.font-medium.text-gray-700.mb-2 "Tag to remove")
+          ($ :select.w-full.px-3.py-2.border.border-gray-300.rounded-md.focus:outline-none.focus:ring-2.focus:ring-blue-500.focus:border-blue-500
+             {:value (:value tag-name-field)
+              :onChange #((:on-change tag-name-field) (.. % -target -value))}
+             ($ :option {:value ""} "Select a tag to remove...")
+             (for [tag all-tags]
+               ($ :option {:key tag :value tag} tag)))
+          (when (:error field-errors)
+            ($ :div.text-sm.text-red-600.mt-1 (:error field-errors)))))))
+
 (forms/reg-form
  :add-tag-to-selected
  {:steps [:main]
@@ -410,40 +444,6 @@
 
 (defn show-remove-tag-modal! [props]
   (rf/dispatch [:modal/show-form :remove-tag-from-selected props]))
-
-(defui AddTagForm [{:keys [form-id]}]
-  (let [{:keys [field-errors]} (forms/use-form form-id)
-        tag-name-field (forms/use-form-field form-id :tag-name)]
-
-    ($ forms/form
-       ($ forms/form-field {:label "Tag to add"
-                            :value (:value tag-name-field)
-                            :on-change (:on-change tag-name-field)
-                            :error (:error tag-name-field)
-                            :required? true}))))
-
-(defui RemoveTagForm [{:keys [form-id selected-examples]}]
-  (let [{:keys [field-errors]} (forms/use-form form-id)
-        tag-name-field (forms/use-form-field form-id :tag-name)
-
-        ;; Get all unique tags from selected examples
-        all-tags (->> selected-examples
-                      (mapcat :tags)
-                      (map name) ; Convert keywords to strings
-                      (distinct)
-                      (sort))]
-
-    ($ forms/form
-       ($ :div
-          ($ :label.block.text-sm.font-medium.text-gray-700.mb-2 "Tag to remove")
-          ($ :select.w-full.px-3.py-2.border.border-gray-300.rounded-md.focus:outline-none.focus:ring-2.focus:ring-blue-500.focus:border-blue-500
-             {:value (:value tag-name-field)
-              :onChange #((:on-change tag-name-field) (.. % -target -value))}
-             ($ :option {:value ""} "Select a tag to remove...")
-             (for [tag all-tags]
-               ($ :option {:key tag :value tag} tag)))
-          (when (:error field-errors)
-            ($ :div.text-sm.text-red-600.mt-1 (:error field-errors)))))))
 
 (defn handle-delete-selected! [module-id dataset-id snapshot-name example-ids]
   (when (js/confirm (str "Are you sure you want to delete " (count example-ids) " selected examples? This action cannot be undone."))

--- a/src/cljs/com/rpl/agent_o_rama/ui/evaluators.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/evaluators.cljs
@@ -28,6 +28,14 @@
      ($ :dd.mt-1.text-sm.leading-6.text-gray-700.sm:col-span-2.sm:mt-0
         children)))
 
+(defui JsonPathTooltip []
+  ($ common/InfoTooltip {:content ($ :div
+                                     "A JSONPath expression to extract a value from the JSON object."
+                                     ($ :br)
+                                     ($ :a.text-blue-300.hover:underline.cursor-pointer
+                                        {:onClick #(js/window.open "https://en.wikipedia.org/wiki/JSONPath" "_blank")}
+                                        "Learn more on Wikipedia."))}))
+
 (defui EvaluatorDetailsModal [{:keys [spec]}]
   (let [{:keys [name type description builder-name builder-params
                 input-json-path output-json-path reference-output-json-path]} spec
@@ -83,18 +91,6 @@
   (rf/dispatch [:modal/show :evaluator-details
                    {:title (str "Evaluator Details: " (:name spec))
                     :component ($ EvaluatorDetailsModal {:spec spec})}]))
-
-;; =============================================================================
-;; JSONPATH TOOLTIP COMPONENT
-;; =============================================================================
-
-(defui JsonPathTooltip []
-  ($ common/InfoTooltip {:content ($ :div
-                                     "A JSONPath expression to extract a value from the JSON object."
-                                     ($ :br)
-                                     ($ :a.text-blue-300.hover:underline.cursor-pointer
-                                        {:onClick #(js/window.open "https://en.wikipedia.org/wiki/JSONPath" "_blank")}
-                                        "Learn more on Wikipedia."))}))
 
 ;; =============================================================================
 ;; Note: get-evaluator-type-badge-style and get-evaluator-type-display

--- a/src/cljs/com/rpl/agent_o_rama/ui/experiments/comparative_detail.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/experiments/comparative_detail.cljs
@@ -76,7 +76,7 @@
                  (set-selected-selector (first selector-eval-names)))
                (when (some? selected-selector)
                  (set-selected-selector nil))))
-           [(count selector-eval-names) (pr-str (sort selector-eval-names)) selected-selector])
+           [selector-eval-names (count selector-eval-names) (pr-str (sort selector-eval-names)) selected-selector])
 
         ;; Collect all evaluator metrics for metadata
         all-evals (reduce (fn [acc run]

--- a/src/cljs/com/rpl/agent_o_rama/ui/experiments/regular_detail.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/experiments/regular_detail.cljs
@@ -132,6 +132,17 @@
      ($ :div.text-xs.font-medium.text-gray-500.uppercase.tracking-wider label)
      ($ :div.text-xl.font-semibold.text-gray-900.mt-1 value)))
 
+(defn format-metric-value [value]
+  (cond
+    (true? value) ($ :span.text-green-700 "True")
+    (false? value) ($ :span.text-red-700 "False")
+    (number? value) (if (and (float? value) (not= value (js/Math.floor value)))
+                      (.toFixed value 2)
+                      (str value))
+    (string? value) (if (> (count value) 20) (str (subs value 0 17) "…") value)
+    (nil? value) ($ :span.italic.text-gray-400 "nil")
+    :else ($ :span.italic.text-gray-400 "…")))
+
 (defui SummaryEvaluatorsMetricsTable [{:keys [summary-evals]}]
   (let [summary-metadata (evaluators/collect-column-metadata summary-evals)]
     (when (seq (:columns summary-metadata))
@@ -197,17 +208,6 @@
 
        ;; Summary Evaluators Table
        ($ SummaryEvaluatorsMetricsTable {:summary-evals summary-evals}))))
-
-(defn format-metric-value [value]
-  (cond
-    (true? value) ($ :span.text-green-700 "True")
-    (false? value) ($ :span.text-red-700 "False")
-    (number? value) (if (and (float? value) (not= value (js/Math.floor value)))
-                      (.toFixed value 2)
-                      (str value))
-    (string? value) (if (> (count value) 20) (str (subs value 0 17) "…") value)
-    (nil? value) ($ :span.italic.text-gray-400 "nil")
-    :else ($ :span.italic.text-gray-400 "…")))
 
 ;; NEW COMPONENTS: Evaluator capsules for compact display within Output column
 (defui EvaluatorCapsule [{:keys [eval-name metric-key metric-value eval-failure eval-invoke module-id columns-metadata]}]

--- a/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/manual_feedback.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/manual_feedback.cljs
@@ -21,12 +21,11 @@
         has-definition? (some? (:metric metric-data))
         
         ;; Fetch metric definition if we have a name but no definition
-        fetch-result (when (and has-metric-name? (not has-definition?))
-                       (queries/use-rpc-query
-                        {:rfq-key ::rpc-hf/get-metrics!!
-                         :params {:module-id module-id
-                                  :filters {:search-string metric-name}}
-                         :enabled? true}))
+        fetch-result (queries/use-rpc-query
+                      {:rfq-key ::rpc-hf/get-metrics!!
+                       :params {:module-id module-id
+                                :filters {:search-string metric-name}}
+                       :enabled? (and has-metric-name? (not has-definition?))})
         
         ;; Extract the metric definition from the fetch result
         fetched-metric (when fetch-result

--- a/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/metrics_index.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/metrics_index.cljs
@@ -43,7 +43,7 @@
                                     (rf/dispatch [:query/invalidate {:query-key-pattern [:human-metrics module-id]}])
                                     (rf/dispatch [:re-frame.query/invalidate-tags [[:human-feedback/metrics module-id]]])))
                            (.catch (fn [err] (js/alert (str "Error: " (if (map? err) (or (:error err) (str err)) (str err)))))))))
-                       [decoded-module-id])]
+                       [module-id decoded-module-id])]
 
     (if-not decoded-module-id
       ($ :div.p-6

--- a/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
@@ -70,34 +70,12 @@
                  (rf/dispatch [:db/set-value (into state-path [:pagination-params]) probe-pagination])
                  (rf/dispatch [:db/set-value (into state-path [:has-more?]) probe-has-more?]))))))
 
-(defn- probe-reverse-pagination!
-  [decoded-module-id decoded-queue-id state-path pagination-params]
-  (-> (rpc/call ::rpc-hf/get-queue-items!!
-                {:module-id decoded-module-id
-                 :queue-name decoded-queue-id
-                 :pagination pagination-params
-                 :limit 1
-                 :include-cursor? true
-                 :reverse? true})
-      (.then (fn [response-data]
-               (let [probe-pagination (:pagination-params response-data)
-                     probe-has-more? (queries/has-more-pages? probe-pagination)]
-                 (rf/dispatch [:db/set-value (into state-path [:reverse-pagination-params]) probe-pagination])
-                 (rf/dispatch [:db/set-value (into state-path [:has-more-before?]) probe-has-more?]))))))
-
 (defn- reconcile-stale-pagination!
-  "After bidirectional merge, forward/reverse cursors can point at loaded items."
+  "After bidirectional merge, the forward cursor can point at an already-loaded item."
   [decoded-module-id decoded-queue-id state-path items]
-  (let [fwd-pagination (get-in @rdb/app-db (into state-path [:pagination-params]))
-        rev-pagination (get-in @rdb/app-db (into state-path [:reverse-pagination-params]))
-        probes (cond-> []
-                 (pagination-already-loaded? fwd-pagination items)
-                 (conj (probe-forward-pagination! decoded-module-id decoded-queue-id state-path fwd-pagination))
-
-                 (pagination-already-loaded? rev-pagination items)
-                 (conj (probe-reverse-pagination! decoded-module-id decoded-queue-id state-path rev-pagination)))]
-    (if (seq probes)
-      (.then (js/Promise.all (clj->js probes)) (fn [_] nil))
+  (let [fwd-pagination (get-in @rdb/app-db (into state-path [:pagination-params]))]
+    (if (pagination-already-loaded? fwd-pagination items)
+      (probe-forward-pagination! decoded-module-id decoded-queue-id state-path fwd-pagination)
       (js/Promise.resolve nil))))
 
 ;; =============================================================================

--- a/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
@@ -70,6 +70,7 @@
         is-loading? (= (:status query-state) :loading)
         is-fetching-more? (:fetching-more? query-state)
         is-fetching-before? (:fetching-before? query-state)
+        bidir-outstanding (:initial-bidir-outstanding query-state)
         error (when (= (:status query-state) :error) (:error query-state))
         initial-needed? (and initial-cursor
                              (not (some #(queue-item-matches? % initial-cursor) data)))]
@@ -186,6 +187,7 @@
       (uix/use-effect
        (fn []
          (when (and enabled?
+                    (nil? bidir-outstanding)
                     (or (empty? data) initial-needed?))
            (if (and initial-needed? initial-cursor include-initial-cursor?)
              (do
@@ -194,7 +196,7 @@
                (fetch-page initial-cursor false true true true))
              (fetch-page initial-cursor false include-initial-cursor? false false)))
          js/undefined)
-       [state-path enabled? data initial-needed? fetch-page initial-cursor include-initial-cursor?])
+       [state-path enabled? bidir-outstanding data initial-needed? fetch-page initial-cursor include-initial-cursor?])
 
       (uix/use-effect
        (fn []

--- a/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
@@ -170,12 +170,15 @@
                                        :error nil
                                        :should-refetch? false}])
                      (fetch-page nil false false false false))
-                   [fetch-page state-path])]
+                   [fetch-page state-path])
 
-      ;; Effect: Force refetch from start if flag is set and cache exists
+          force-refetch-applied (uix/use-ref false)]
+
+      ;; Effect: Force refetch from start if flag is set and cache exists (once per mount)
       (uix/use-effect
        (fn []
-         (when (and force-from-start? (seq data) enabled?)
+         (when (and force-from-start? (not @force-refetch-applied) (seq data) enabled?)
+           (reset! force-refetch-applied true)
            (refetch))
          js/undefined)
        [force-from-start? data enabled? refetch])

--- a/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
@@ -56,6 +56,14 @@
   (and (queries/has-more-pages? pagination-params)
        (some #(queue-item-matches? % pagination-params) items)))
 
+(defn- promise-with-timeout
+  [p timeout-ms]
+  (js/Promise.race
+   [p
+    (js/Promise.
+     (fn [resolve]
+       (js/setTimeout #(resolve :timeout) timeout-ms)))]))
+
 (defn- probe-forward-pagination!
   [decoded-module-id decoded-queue-id state-path pagination-params]
   (-> (rpc/call ::rpc-hf/get-queue-items!!
@@ -68,14 +76,18 @@
                (let [probe-pagination (:pagination-params response-data)
                      probe-has-more? (queries/has-more-pages? probe-pagination)]
                  (rf/dispatch [:db/set-value (into state-path [:pagination-params]) probe-pagination])
-                 (rf/dispatch [:db/set-value (into state-path [:has-more?]) probe-has-more?]))))))
+                 (rf/dispatch [:db/set-value (into state-path [:has-more?]) probe-has-more?]))))
+      (.catch (fn [_] nil))))
 
 (defn- reconcile-stale-pagination!
   "After bidirectional merge, the forward cursor can point at an already-loaded item."
   [decoded-module-id decoded-queue-id state-path items]
   (let [fwd-pagination (get-in @rdb/app-db (into state-path [:pagination-params]))]
     (if (pagination-already-loaded? fwd-pagination items)
-      (probe-forward-pagination! decoded-module-id decoded-queue-id state-path fwd-pagination)
+      (-> (promise-with-timeout
+           (probe-forward-pagination! decoded-module-id decoded-queue-id state-path fwd-pagination)
+           10000)
+          (.then (fn [_] nil)))
       (js/Promise.resolve nil))))
 
 ;; =============================================================================

--- a/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
@@ -50,6 +50,56 @@
          (sort-by (comp str :id))
          vec)))
 
+(defn- pagination-already-loaded?
+  "True when `pagination-params` points at an item already present in `items`."
+  [pagination-params items]
+  (and (queries/has-more-pages? pagination-params)
+       (some #(queue-item-matches? % pagination-params) items)))
+
+(defn- probe-forward-pagination!
+  [decoded-module-id decoded-queue-id state-path pagination-params]
+  (-> (rpc/call ::rpc-hf/get-queue-items!!
+                {:module-id decoded-module-id
+                 :queue-name decoded-queue-id
+                 :pagination pagination-params
+                 :limit 1
+                 :include-cursor? true})
+      (.then (fn [response-data]
+               (let [probe-pagination (:pagination-params response-data)
+                     probe-has-more? (queries/has-more-pages? probe-pagination)]
+                 (rf/dispatch [:db/set-value (into state-path [:pagination-params]) probe-pagination])
+                 (rf/dispatch [:db/set-value (into state-path [:has-more?]) probe-has-more?]))))))
+
+(defn- probe-reverse-pagination!
+  [decoded-module-id decoded-queue-id state-path pagination-params]
+  (-> (rpc/call ::rpc-hf/get-queue-items!!
+                {:module-id decoded-module-id
+                 :queue-name decoded-queue-id
+                 :pagination pagination-params
+                 :limit 1
+                 :include-cursor? true
+                 :reverse? true})
+      (.then (fn [response-data]
+               (let [probe-pagination (:pagination-params response-data)
+                     probe-has-more? (queries/has-more-pages? probe-pagination)]
+                 (rf/dispatch [:db/set-value (into state-path [:reverse-pagination-params]) probe-pagination])
+                 (rf/dispatch [:db/set-value (into state-path [:has-more-before?]) probe-has-more?]))))))
+
+(defn- reconcile-stale-pagination!
+  "After bidirectional merge, forward/reverse cursors can point at loaded items."
+  [decoded-module-id decoded-queue-id state-path items]
+  (let [fwd-pagination (get-in @rdb/app-db (into state-path [:pagination-params]))
+        rev-pagination (get-in @rdb/app-db (into state-path [:reverse-pagination-params]))
+        probes (cond-> []
+                 (pagination-already-loaded? fwd-pagination items)
+                 (conj (probe-forward-pagination! decoded-module-id decoded-queue-id state-path fwd-pagination))
+
+                 (pagination-already-loaded? rev-pagination items)
+                 (conj (probe-reverse-pagination! decoded-module-id decoded-queue-id state-path rev-pagination)))]
+    (if (seq probes)
+      (.then (js/Promise.all (clj->js probes)) (fn [_] nil))
+      (js/Promise.resolve nil))))
+
 ;; =============================================================================
 ;; QUEUE ITEMS HOOK
 ;; =============================================================================
@@ -70,6 +120,7 @@
         is-loading? (= (:status query-state) :loading)
         is-fetching-more? (:fetching-more? query-state)
         is-fetching-before? (:fetching-before? query-state)
+        bidir-outstanding (:initial-bidir-outstanding query-state)
         error (when (= (:status query-state) :error) (:error query-state))
         initial-needed? (and initial-cursor
                              (not (some #(queue-item-matches? % initial-cursor) data)))]
@@ -101,20 +152,19 @@
                                            (rf/dispatch [:db/set-value (into state-path [:fetching-more?]) false]))
                                          (let [new-items (or (:items response-data) [])
                                                new-pagination (:pagination-params response-data)
-                                               new-has-more? (queries/has-more-pages? new-pagination)
                                                current-data (or (get-in @rdb/app-db (into state-path [:data])) [])
+                                               merged-data (cond
+                                                             append?
+                                                             (vec (concat current-data new-items))
+
+                                                             (and merge? (seq current-data))
+                                                             (merge-queue-items current-data new-items)
+
+                                                             :else
+                                                             new-items)
+                                               new-has-more? (queries/has-more-pages? new-pagination)
                                                update-pagination? (not reverse?)]
-                                           (cond
-                                             append?
-                                             (rf/dispatch [:db/set-value (into state-path [:data])
-                                                              (vec (concat current-data new-items))])
-
-                                             (and merge? (seq current-data))
-                                             (rf/dispatch [:db/set-value (into state-path [:data])
-                                                              (merge-queue-items current-data new-items)])
-
-                                             :else
-                                             (rf/dispatch [:db/set-value (into state-path [:data]) new-items]))
+                                           (rf/dispatch [:db/set-value (into state-path [:data]) merged-data])
                                            (if update-pagination?
                                              (do
                                                (rf/dispatch [:db/set-value (into state-path [:pagination-params]) new-pagination])
@@ -123,14 +173,23 @@
                                                (rf/dispatch [:db/set-value (into state-path [:reverse-pagination-params]) new-pagination])
                                                (rf/dispatch [:db/set-value (into state-path [:has-more-before?]) new-has-more?])))
                                            (let [bidir-path (into state-path [:initial-bidir-outstanding])
-                                                 bidir (get-in @rdb/app-db bidir-path)]
+                                                 bidir (get-in @rdb/app-db bidir-path)
+                                                 finish-loading (fn []
+                                                                  (rf/dispatch [:db/set-value bidir-path nil])
+                                                                  (rf/dispatch [:db/set-value (into state-path [:status]) :success]))
+                                                 finish-error (fn [err]
+                                                                (rf/dispatch [:db/set-value bidir-path nil])
+                                                                (rf/dispatch [:db/set-value (into state-path [:status]) :error])
+                                                                (rf/dispatch [:db/set-value (into state-path [:error])
+                                                                             (if (map? err) (or (:error err) (str err)) (str err))]))]
                                              (if (number? bidir)
                                                (let [n' (dec bidir)]
                                                  (if (pos? n')
                                                    (rf/dispatch [:db/set-value bidir-path n'])
-                                                   (do
-                                                     (rf/dispatch [:db/set-value bidir-path nil])
-                                                     (rf/dispatch [:db/set-value (into state-path [:status]) :success]))))
+                                                   (let [final-items (or (get-in @rdb/app-db (into state-path [:data])) [])]
+                                                     (-> (reconcile-stale-pagination! decoded-module-id decoded-queue-id state-path final-items)
+                                                         (.then (fn [_] (finish-loading)))
+                                                         (.catch finish-error)))))
                                                (rf/dispatch [:db/set-value (into state-path [:status]) :success]))))))
                                 (.catch (fn [err]
                                           (if reverse?
@@ -174,10 +233,17 @@
 
       (uix/use-effect
        (fn []
-         (when (and enabled? (or (empty? data) initial-needed?))
-           (fetch-page initial-cursor false include-initial-cursor? false false))
+         (when (and enabled?
+                    (nil? bidir-outstanding)
+                    (or (empty? data) initial-needed?))
+           (if (and initial-needed? initial-cursor include-initial-cursor?)
+             (do
+               (rf/dispatch [:db/set-value (into state-path [:initial-bidir-outstanding]) 2])
+               (fetch-page initial-cursor false true true false)
+               (fetch-page initial-cursor false true true true))
+             (fetch-page initial-cursor false include-initial-cursor? false false)))
          js/undefined)
-       [state-path enabled? data initial-needed? fetch-page initial-cursor include-initial-cursor?])
+       [state-path enabled? bidir-outstanding data initial-needed? fetch-page initial-cursor include-initial-cursor?])
 
       (uix/use-effect
        (fn []
@@ -187,7 +253,7 @@
        [should-refetch? enabled? refetch state-path])
 
       {:data data
-       :isLoading is-loading?
+       :isLoading (or is-loading? (some? bidir-outstanding))
        :isFetchingMore is-fetching-more?
        :isFetchingBefore is-fetching-before?
        :hasMore has-more?

--- a/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
@@ -55,7 +55,7 @@
 ;; =============================================================================
 
 (defhook use-queue-items
-  [{:keys [module-id queue-id initial-cursor include-initial-cursor? force-from-start? enabled?]
+  [{:keys [module-id queue-id initial-cursor include-initial-cursor? enabled?]
     :or {enabled? true}}]
   (let [decoded-module-id (common/url-decode module-id)
         decoded-queue-id (common/url-decode queue-id)
@@ -70,7 +70,6 @@
         is-loading? (= (:status query-state) :loading)
         is-fetching-more? (:fetching-more? query-state)
         is-fetching-before? (:fetching-before? query-state)
-        bidir-outstanding (:initial-bidir-outstanding query-state)
         error (when (= (:status query-state) :error) (:error query-state))
         initial-needed? (and initial-cursor
                              (not (some #(queue-item-matches? % initial-cursor) data)))]
@@ -171,32 +170,14 @@
                                        :error nil
                                        :should-refetch? false}])
                      (fetch-page nil false false false false))
-                   [fetch-page state-path])
-
-          force-refetch-applied (uix/use-ref false)]
-
-      ;; Effect: Force refetch from start if flag is set and cache exists (once per mount)
-      (uix/use-effect
-       (fn []
-         (when (and force-from-start? (not @force-refetch-applied) (seq data) enabled?)
-           (reset! force-refetch-applied true)
-           (refetch))
-         js/undefined)
-       [force-from-start? data enabled? refetch])
+                   [fetch-page state-path])]
 
       (uix/use-effect
        (fn []
-         (when (and enabled?
-                    (nil? bidir-outstanding)
-                    (or (empty? data) initial-needed?))
-           (if (and initial-needed? initial-cursor include-initial-cursor?)
-             (do
-               (rf/dispatch [:db/set-value (into state-path [:initial-bidir-outstanding]) 2])
-               (fetch-page initial-cursor false true true false)
-               (fetch-page initial-cursor false true true true))
-             (fetch-page initial-cursor false include-initial-cursor? false false)))
+         (when (and enabled? (or (empty? data) initial-needed?))
+           (fetch-page initial-cursor false include-initial-cursor? false false))
          js/undefined)
-       [state-path enabled? bidir-outstanding data initial-needed? fetch-page initial-cursor include-initial-cursor?])
+       [state-path enabled? data initial-needed? fetch-page initial-cursor include-initial-cursor?])
 
       (uix/use-effect
        (fn []

--- a/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
@@ -178,7 +178,7 @@
          (when (and force-from-start? (seq data) enabled?)
            (refetch))
          js/undefined)
-       [force-from-start?]) ; Only run on mount
+       [force-from-start? data enabled? refetch])
 
       (uix/use-effect
        (fn []
@@ -191,7 +191,7 @@
                (fetch-page initial-cursor false true true true))
              (fetch-page initial-cursor false include-initial-cursor? false false)))
          js/undefined)
-       [enabled? data initial-needed? fetch-page initial-cursor include-initial-cursor?])
+       [state-path enabled? data initial-needed? fetch-page initial-cursor include-initial-cursor?])
 
       (uix/use-effect
        (fn []

--- a/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/common.cljs
@@ -231,7 +231,8 @@
        [should-refetch? enabled? refetch state-path])
 
       {:data data
-       :isLoading (or is-loading? (some? bidir-outstanding))
+       :isBidirLoading (some? bidir-outstanding)
+       :isLoading is-loading?
        :isFetchingMore is-fetching-more?
        :isFetchingBefore is-fetching-before?
        :hasMore has-more?

--- a/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/detail.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/detail.cljs
@@ -2,7 +2,7 @@
   "Human feedback queue detail page (queue info + items list)."
   (:require
    [com.rpl.agent-o-rama.ui.re-frame :as aor-rf]
-   [uix.core :refer [defui $]]
+   [uix.core :as uix :refer [defui $]]
    [uix.re-frame :refer [use-subscribe]]
    [reitit.frontend.easy :as rfe]
    ["@heroicons/react/24/outline" :refer [PencilIcon]]
@@ -111,16 +111,22 @@
         queue-info-error error
 
         ;; Query for paginated queue items
-        ;; Force refetch from start to ensure list always shows items 0-19
-        {:keys [data isLoading isFetchingMore hasMore loadMore error]}
+        {:keys [data isLoading isFetchingMore hasMore loadMore error refetch]}
         (q-common/use-queue-items
          {:module-id module-id
           :queue-id queue-id
-          :force-from-start? true
           :enabled? (boolean (and decoded-module-id decoded-queue-id))})
         items-error error
 
-        queue-items data]
+        queue-items data
+
+        ;; Always refetch from start when opening the queue detail page
+        _ (uix/use-effect
+           (fn []
+             (when (boolean (and decoded-module-id decoded-queue-id))
+               (refetch))
+             js/undefined)
+           [module-id queue-id refetch decoded-module-id decoded-queue-id])]
 
     (cond
       (or loading? isLoading)

--- a/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/item_detail.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/item_detail.cljs
@@ -83,7 +83,8 @@
 
         ;; Fetch queue items with shared cache for review session
         ;; If item isn't in cache yet, load from its cursor and merge.
-        {:keys [data isLoading hasMore hasMoreBefore loadMore loadMoreBefore]}
+        {:keys [data isLoading isFetchingMore isFetchingBefore
+                hasMore hasMoreBefore loadMore loadMoreBefore]}
         (q-common/use-queue-items
          {:module-id module-id
           :queue-id queue-id
@@ -103,6 +104,7 @@
         ;; Navigation:
         ;; - Previous disabled if we're at index 0 (started from URL cursor)
         ;; - Next enabled if there are more items in array OR hasMore on backend
+        nav-busy? (or pending-next? pending-prev? isFetchingMore isFetchingBefore)
         has-prev? (and current-idx (or (> current-idx 0) hasMoreBefore))
         has-next? (and current-idx
                        (or (< current-idx (dec (count items)))
@@ -250,30 +252,39 @@
 
     (uix/use-effect
      (fn []
-       (when (and pending-next? next-item-id)
-         (set-pending-next? false)
-         (rfe/push-state :module/human-feedback-queue-item
-                         {:module-id module-id
-                          :queue-id queue-id
-                          :item-id next-item-id}))
+       (cond
+         (and pending-next? next-item-id)
+         (do
+           (set-pending-next? false)
+           (rfe/push-state :module/human-feedback-queue-item
+                           {:module-id module-id
+                            :queue-id queue-id
+                            :item-id next-item-id}))
+
+         (and pending-next? (not isFetchingMore) (not hasMore))
+         (set-pending-next? false))
        js/undefined)
-     [pending-next? next-item-id module-id queue-id])
+     [pending-next? next-item-id isFetchingMore hasMore module-id queue-id])
 
     (uix/use-effect
      (fn []
-       (when (and pending-prev? current-idx (> current-idx 0) prev-item-id)
-         (set-pending-prev? false)
-         (rfe/push-state :module/human-feedback-queue-item
-                         {:module-id module-id
-                          :queue-id queue-id
-                          :item-id prev-item-id}))
+       (cond
+         (and pending-prev? prev-item-id)
+         (do
+           (set-pending-prev? false)
+           (rfe/push-state :module/human-feedback-queue-item
+                           {:module-id module-id
+                            :queue-id queue-id
+                            :item-id prev-item-id}))
+
+         (and pending-prev? (not isFetchingBefore) (not hasMoreBefore))
+         (set-pending-prev? false))
        js/undefined)
-     [pending-prev? current-idx prev-item-id module-id queue-id])
+     [pending-prev? prev-item-id isFetchingBefore hasMoreBefore module-id queue-id])
 
     (cond
-      ;; Loading state — only block on items until we have the current item;
-      ;; queue info can load in the background for rubric metadata.
-      (and items-loading? (not current-item))
+      ;; Block until queue items finish loading (including bidirectional + reconcile).
+      items-loading?
       ($ :div.p-6
          ($ :div.text-center.text-gray-500 "Loading..."))
 
@@ -291,14 +302,14 @@
                (str "Review Item: " item-id))
             ($ :div.flex.gap-2
                ($ :button.px-3.py-2.border.border-gray-300.rounded-md.hover:bg-gray-50.transition-colors.disabled:opacity-50.disabled:cursor-not-allowed.cursor-pointer
-                  {:disabled (not has-prev?)
+                  {:disabled (or nav-busy? (not has-prev?))
                    :data-testid "previous-item-button"
-                   :onClick #(when has-prev? (handle-prev))}
+                   :onClick #(when (and has-prev? (not nav-busy?)) (handle-prev))}
                   ($ ChevronLeftIcon {:className "h-5 w-5"}))
                ($ :button.px-3.py-2.border.border-gray-300.rounded-md.hover:bg-gray-50.transition-colors.disabled:opacity-50.disabled:cursor-not-allowed.cursor-pointer
-                  {:disabled (not has-next?)
+                  {:disabled (or nav-busy? (not has-next?))
                    :data-testid "next-item-button"
-                   :onClick #(when has-next? (handle-next))}
+                   :onClick #(when (and has-next? (not nav-busy?)) (handle-next))}
                   ($ ChevronRightIcon {:className "h-5 w-5"}))))
 
          ;; Target Info Panel (Agent/Node with trace link)

--- a/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/item_detail.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/item_detail.cljs
@@ -271,13 +271,14 @@
      [pending-prev? current-idx prev-item-id module-id queue-id])
 
     (cond
-      ;; Loading state
-      (or queue-info-loading? items-loading?)
+      ;; Loading state — only block on items until we have the current item;
+      ;; queue info can load in the background for rubric metadata.
+      (and items-loading? (not current-item))
       ($ :div.p-6
          ($ :div.text-center.text-gray-500 "Loading..."))
 
       ;; Item not found
-      (not current-item)
+      (and (not items-loading?) (not current-item))
       ($ :div.p-6
          ($ :div.text-center.text-gray-500 "Item not found"))
 

--- a/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/item_detail.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/human_feedback/queues/item_detail.cljs
@@ -83,7 +83,7 @@
 
         ;; Fetch queue items with shared cache for review session
         ;; If item isn't in cache yet, load from its cursor and merge.
-        {:keys [data isLoading isFetchingMore isFetchingBefore
+        {:keys [data isLoading isBidirLoading isFetchingMore isFetchingBefore
                 hasMore hasMoreBefore loadMore loadMoreBefore]}
         (q-common/use-queue-items
          {:module-id module-id
@@ -283,8 +283,8 @@
      [pending-prev? prev-item-id isFetchingBefore hasMoreBefore module-id queue-id])
 
     (cond
-      ;; Block until queue items finish loading (including bidirectional + reconcile).
-      items-loading?
+      ;; Block during bidirectional initial load; otherwise show once the item is available.
+      (or isBidirLoading (and items-loading? (not current-item)))
       ($ :div.p-6
          ($ :div.text-center.text-gray-500 "Loading..."))
 

--- a/src/cljs/com/rpl/agent_o_rama/ui/invocations/graph_view.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/invocations/graph_view.cljs
@@ -28,6 +28,9 @@
    ["react" :refer [useState useCallback useEffect]]
    ["@heroicons/react/24/outline" :refer [ExclamationTriangleIcon ArrowPathIcon ArrowTopRightOnSquareIcon PencilIcon XMarkIcon]]))
 
+(defn- to-pretty-json [val]
+  (js/JSON.stringify (clj->js val) nil 2))
+
 (defui ExceptionDetailModal [{:keys [title content]}]
   ($ :div.p-6.space-y-4
      ($ :pre.text-xs.bg-gray-50.p-3.rounded.border.overflow-auto.max-h-80.font-mono
@@ -587,9 +590,6 @@
         node-name (:node data)
         original-input (:input data)
 
-        ;; Function to pretty-print ClojureScript data to a JSON string
-        to-pretty-json (fn [val] (js/JSON.stringify (clj->js val) nil 2))
-
         ;; Initial text for the textarea
         current-input (get changed-nodes node-id (to-pretty-json original-input))
         [input-text set-input-text] (uix/use-state current-input)
@@ -606,7 +606,7 @@
          (let [original-input (:input selected-node-data)
                current-input (get changed-nodes node-id (to-pretty-json original-input))]
            (set-input-text current-input))))
-     [selected-node-data changed-nodes node-id])
+     [to-pretty-json selected-node-data changed-nodes node-id])
 
     (when selected-node-data
       ($ :div {:className (common/cn "mt-6 bg-white shadow-lg rounded-lg border border-gray-200 max-w-4xl")}

--- a/src/cljs/com/rpl/agent_o_rama/ui/queries.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/queries.cljs
@@ -33,7 +33,7 @@
                  (fn []
                    (when enabled?
                      (rf/dispatch [:re-frame.query/refetch-query rfq-key params])))
-                 [enabled? rfq-key params-sig])]
+                 [enabled? rfq-key params params-sig])]
     {:data data
      :loading? loading?
      :fetching? (boolean fetching?)
@@ -76,12 +76,12 @@
                      (fn []
                        (when (and enabled? has-next?)
                          (rfq/fetch-next-page rfq-key params')))
-                     [enabled? has-next? rfq-key params-sig])
+                     [enabled? has-next? rfq-key params' params-sig])
           refetch (uix/use-callback
                    (fn []
                      (when enabled?
                        (rf/dispatch [:re-frame.query/refetch-infinite-query rfq-key params'])))
-                   [enabled? rfq-key params-sig])]
+                   [enabled? rfq-key params' params-sig])]
       {:data items
        :isLoading (and loading? (empty? items))
        :isFetchingMore (boolean fetching-next?)

--- a/src/cljs/com/rpl/agent_o_rama/ui/searchable_selector.cljs
+++ b/src/cljs/com/rpl/agent_o_rama/ui/searchable_selector.cljs
@@ -149,7 +149,7 @@
            (when (not= search-term label)
              (set-search-term! label))))
        js/undefined)
-     [value selected-items multi-select?])
+     [search-term item-label-fn value selected-items multi-select?])
 
     ;; Refetch when dropdown opens
     (uix/use-effect

--- a/test/e2e/queue-review-pagination.spec.js
+++ b/test/e2e/queue-review-pagination.spec.js
@@ -192,7 +192,7 @@ test.describe('Queue Review Pagination', () => {
   });
 
   test('should load from cursor when accessing deep item via URL', async ({ page }) => {
-    test.setTimeout(300000); // 5 minutes — many invocations + cold navigations
+    test.setTimeout(600000); // 10 minutes — 30 invocations + cold navigations on CI
     
     const uniqueId = randomUUID().substring(0, 8);
     const queueName = `e2e-cursor-queue-${uniqueId}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes all UIx compiler warnings (23 → 0) across ClojureScript UI components.

## Changes

- Add missing hook dependencies in `use-effect`/`use-callback` across queries, charts, analytics, graph views, and queue components
- Fix undeclared-var warnings via forward reference reordering
- Extract `static-chart-card` component to fix hook-in-loop in analytics
- Fix conditional hook call in manual feedback
- Restore bidirectional queue item loading for deep URL navigation with stale-pagination reconcile
- Harden queue item prev/next navigation during pagination fetches

## Test plan

- [x] `lein with-profile +ui run -m shadow.cljs.devtools.cli --npm compile :frontend` — 0 warnings
- [x] `queue-review-pagination` e2e — passes locally (5/5 runs)
- [x] `human-feedback-queues` e2e — passes locally
- [x] Full Playwright suite — 50 passed (prior run)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5840650-a75c-464e-b35d-6bfaa18adb18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5840650-a75c-464e-b35d-6bfaa18adb18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

